### PR TITLE
Feature/output formats

### DIFF
--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
 
 import graphlib
-import rich
 
 from sigmatcher.definitions import (
     ClassDefinition,
@@ -264,6 +263,4 @@ def analyze(
             results[analyzer_name] = analyzer.analyze(unpacked_path, app_version, results)
         except (MatchError, InvalidMacroModifierError) as e:
             results[analyzer_name] = e
-            rich.print(f"[yellow]{e!s}[/yellow]")
-
-    rich.print(results)
+    return results

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -122,8 +122,10 @@ class ClassAnalyzer(Analyzer):
             class_definition_line = f.readline().rstrip("\n")
         _, _, raw_class_name = class_definition_line.rpartition(" ")
         new_class = Class.from_java_representation(raw_class_name)
-        original_class = Class(self.definition.name, self.definition.package or new_class.pacakge)
-        return MatchedClass(original_class, new_class, match, [], [])
+        original_class = Class(name=self.definition.name, pacakge=self.definition.package or new_class.pacakge)
+        return MatchedClass(
+            original=original_class, new=new_class, smali_file=match, matched_methods=[], matched_fields=[]
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -146,8 +148,8 @@ class FieldAnalyzer(Analyzer):
 
         new_field = Field.from_java_representation(raw_field_name)
         # TODO: should we get the types for the original field from the definition?
-        original_field = Field(self.definition.name, new_field.type)
-        matched_field = MatchedField(original_field, new_field)
+        original_field = Field(name=self.definition.name, type=new_field.type)
+        matched_field = MatchedField(original=original_field, new=new_field)
         parent_class_result.matched_fields.append(matched_field)
         return matched_field
 
@@ -184,8 +186,10 @@ class MethodAnalyzer(Analyzer):
 
         new_method = Method.from_java_representation(raw_method_name)
         # TODO: should we get the types for the original method from the definition?
-        original_method = Method(self.definition.name, new_method.argument_types, new_method.return_type)
-        matched_method = MatchedMethod(original_method, new_method)
+        original_method = Method(
+            name=self.definition.name, argument_types=new_method.argument_types, return_type=new_method.return_type
+        )
+        matched_method = MatchedMethod(original=original_method, new=new_method)
         parent_class_result.matched_methods.append(matched_method)
         return matched_method
 

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -60,10 +60,9 @@ class BaseSignature(ABC, pydantic.BaseModel, frozen=True):
         raise NotImplementedError()
 
     def resolve_macro(
-        self, results: Dict[str, Union[Result, Exception, None]], result_identifier: str, result_modifier: str
+        self, results: Dict[str, Union[Result, Exception]], result_identifier: str, result_modifier: str
     ) -> str:
         result = results[result_identifier]
-        assert result is not None
         assert not isinstance(result, Exception)
 
         try:
@@ -75,7 +74,7 @@ class BaseSignature(ABC, pydantic.BaseModel, frozen=True):
         return resolved_macro
 
     @abstractmethod
-    def resolve_macros(self, results: Dict[str, Union[Result, Exception, None]]) -> Self:
+    def resolve_macros(self, results: Dict[str, Union[Result, Exception]]) -> Self:
         raise NotImplementedError()
 
     def is_in_version_range(self, app_version: str) -> bool:
@@ -115,7 +114,7 @@ class BaseRegexSignature(BaseSignature, pydantic.BaseModel, frozen=True):
     def _get_raw_macros(self) -> Set[str]:
         return set(self.MACRO_REGEX.findall(self.signature.pattern))
 
-    def resolve_macros(self, results: Dict[str, Union[Result, Exception, None]]) -> Self:
+    def resolve_macros(self, results: Dict[str, Union[Result, Exception]]) -> Self:
         if not self._get_raw_macros:
             return self
 
@@ -159,7 +158,7 @@ class TreeSitterSignature(BaseSignature, pydantic.BaseModel, frozen=True):
     def get_dependencies(self) -> List[str]:
         raise NotImplementedError("TreeSitter signatures are not supported yet.")
 
-    def resolve_macros(self, results: Dict[str, Union[Result, Exception, None]]) -> Self:
+    def resolve_macros(self, results: Dict[str, Union[Result, Exception]]) -> Self:
         raise NotImplementedError("TreeSitter signatures are not supported yet.")
 
 

--- a/src/sigmatcher/formats.py
+++ b/src/sigmatcher/formats.py
@@ -1,0 +1,80 @@
+import enum
+import json
+from abc import ABC, abstractmethod
+from io import StringIO
+from typing import Dict, Type
+
+import pydantic
+
+from sigmatcher.results import MatchedClass, MatchedField, MatchedMethod
+
+
+class Formater(ABC):
+    @abstractmethod
+    def convert(self, matched_classes: Dict[str, MatchedClass]) -> str:
+        raise NotImplementedError()
+
+
+class RawFormater(Formater):
+    def convert(self, matched_classes: Dict[str, MatchedClass]) -> str:
+        return pydantic.RootModel[Dict[str, MatchedClass]](matched_classes).model_dump_json(indent=4)
+
+
+class LegacyFormater(Formater):
+    def convert(self, matched_classes: Dict[str, MatchedClass]) -> str:
+        return json.dumps(
+            {
+                matched_class.original.name: {
+                    "className": f"{matched_class.new.pacakge}.{matched_class.new.name}",
+                    "methods": {method.original.name: method.new.name for method in matched_class.matched_methods},
+                    "fields": {field.original.name: field.new.name for field in matched_class.matched_fields},
+                }
+                for matched_class in matched_classes.values()
+            },
+            indent=4,
+            sort_keys=True,
+        )
+
+
+class EnigmaFormater(Formater):
+    def convert_field(self, field: MatchedField) -> str:
+        return f"\tFIELD {field.new.name} {field.original.name} {field.new.type}\n"
+
+    def convert_method(self, method: MatchedMethod) -> str:
+        return (
+            f"\tMETHOD {method.new.name} {method.original.name} ({method.new.argument_types}){method.new.return_type}\n"
+        )
+
+    def convert_class(self, matched_class: MatchedClass) -> str:
+        result = StringIO()
+        result.write(
+            f"CLASS {matched_class.new.to_java_representation()} {matched_class.original.to_java_representation()}\n"
+        )
+        for field in matched_class.matched_fields:
+            result.write(self.convert_field(field))
+        for method in matched_class.matched_methods:
+            result.write(self.convert_method(method))
+        return result.getvalue()
+
+    def convert(self, matched_classes: Dict[str, MatchedClass]) -> str:
+        final = StringIO()
+        for matched_class in matched_classes.values():
+            final.write(self.convert_class(matched_class))
+        return final.getvalue()
+
+
+class OutputFormat(str, enum.Enum):
+    RAW = "raw"
+    ENIGMA = "enigma"
+    LEGACY = "legacy"
+
+
+FORMAT_TO_FORMATTER: Dict[OutputFormat, Type[Formater]] = {
+    OutputFormat.RAW: RawFormater,
+    OutputFormat.ENIGMA: EnigmaFormater,
+    OutputFormat.LEGACY: LegacyFormater,
+}
+
+
+def convert_to_format(matched_classes: Dict[str, MatchedClass], output_format: OutputFormat) -> str:
+    return FORMAT_TO_FORMATTER[output_format]().convert(matched_classes)

--- a/src/sigmatcher/results.py
+++ b/src/sigmatcher/results.py
@@ -1,4 +1,3 @@
-import dataclasses
 import sys
 from pathlib import Path
 from typing import List, Union
@@ -8,30 +7,29 @@ if sys.version_info < (3, 10):
 else:
     from typing import TypeAlias
 
+import pydantic
 
-@dataclasses.dataclass
-class Export:
+
+class Export(pydantic.BaseModel):
     value: str
 
 
-@dataclasses.dataclass
-class MatchedExport:
+class MatchedExport(pydantic.BaseModel):
     new: Export
 
     @classmethod
     def from_value(cls, value: str) -> "MatchedExport":
-        return cls(Export(value))
+        return cls(new=Export(value=value))
 
 
-@dataclasses.dataclass
-class Field:
+class Field(pydantic.BaseModel):
     name: str
     type: str
 
     @classmethod
     def from_java_representation(cls, java_representation: str) -> "Field":
         name, _, field_type = java_representation.partition(":")
-        return cls(name, field_type)
+        return cls(name=name, type=field_type)
 
     def to_java_representation(self) -> str:
         return f"{self.name}:{self.type}"
@@ -41,14 +39,12 @@ class Field:
         return self.to_java_representation()
 
 
-@dataclasses.dataclass
-class MatchedField:
+class MatchedField(pydantic.BaseModel):
     original: Field
     new: Field
 
 
-@dataclasses.dataclass
-class Method:
+class Method(pydantic.BaseModel):
     name: str
     argument_types: str
     return_type: str
@@ -57,7 +53,7 @@ class Method:
     def from_java_representation(cls, java_representation: str) -> "Method":
         name, _, types = java_representation.partition("(")
         argument_types, _, return_type = types.partition(")")
-        return cls(name, argument_types, return_type)
+        return cls(name=name, argument_types=argument_types, return_type=return_type)
 
     def to_java_representation(self) -> str:
         return f"{self.name}({self.argument_types}){self.return_type}"
@@ -67,21 +63,19 @@ class Method:
         return self.to_java_representation()
 
 
-@dataclasses.dataclass
-class MatchedMethod:
+class MatchedMethod(pydantic.BaseModel):
     original: Method
     new: Method
 
 
-@dataclasses.dataclass
-class Class:
+class Class(pydantic.BaseModel):
     name: str
     pacakge: str
 
     @classmethod
     def from_java_representation(cls, java_representation: str) -> "Class":
         package, _, name = java_representation[1:-1].replace("/", ".").rpartition(".")
-        return cls(name, package)
+        return cls(name=name, pacakge=package)
 
     def to_java_representation(self) -> str:
         return f"L{self.pacakge}.{self.name};".replace(".", "/")
@@ -91,11 +85,10 @@ class Class:
         return self.to_java_representation()
 
 
-@dataclasses.dataclass
-class MatchedClass:
+class MatchedClass(pydantic.BaseModel):
     original: Class
     new: Class
-    smali_file: Path
+    smali_file: Path = pydantic.Field(..., exclude=True)
     matched_methods: List[MatchedMethod]
     matched_fields: List[MatchedField]
 


### PR DESCRIPTION
Add `--output-format` to choose the output mapping format.

Right now 3 formats are implemented:
* `Raw` - The raw output of the matched classes.
* `Legcay` - The same format as my old analyzer.
* `Enigma` - Fabric's mapping format. Can be used to import mappings into jadx.

In the future I plan to add a new `format` subcommand, which will be able to convert between different formats.