### PR TITLE
Fix version parsing

### DIFF
--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -170,6 +170,8 @@ def analyze(
     apktool_yaml_file = unpacked_path / "apktool.yml"
     with apktool_yaml_file.open() as f:
         apk_version = yaml.safe_load(f)["versionInfo"]["versionName"]
+    if isinstance(apk_version, float | int):
+        apk_version = str(apk_version)
     if not isinstance(apk_version, str):
         stderr_console.print("[yellow][Warning][/yellow] No version was found in the APK. Using 0.0.0.0")
         apk_version = "0.0.0.0"


### PR DESCRIPTION
If the apk version has only one dot, it's parsed as a float. If it has no dots, it's parsed as an int.

Example `apktool.yml` to reproduce: https://mega.en.uptodown.com/android/download

```yaml
version: 2.12.0
apkFileName: uptodown-mega.privacy.android.app.apk
sdkInfo:
  minSdkVersion: 21
  targetSdkVersion: 34
versionInfo:
  versionCode: 684
  versionName: 6.84
doNotCompress:
- arsc
- jpg
- ogg
- png
- webp
- assets/dexopt/baseline.prof
- assets/dexopt/baseline.profm
```