### PR TITLE
Allow finding .bat files on Windows, matching the behavior of Windows shells

### DIFF
--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -93,9 +93,10 @@ def schema(
 
 
 def apktool_callback(value: str) -> str:
-    if shutil.which(value) is None:
+    resolved_path = shutil.which(value)
+    if resolved_path is None:
         raise typer.BadParameter("Cannot find the apktool executable")
-    return value
+    return resolved_path
 
 
 @app.command()


### PR DESCRIPTION
The official apktool script on Windows is a batch file, and it doesn't get picked up by shutil.which.

https://github.com/iBotPeaches/Apktool/blob/main/scripts/windows/apktool.bat