### PR TITLE
feat: Add dynamic signatures for analyzing renames at runtime with patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+A companion `AGENTS.md` at the repo root has a more detailed agent-oriented breakdown (commands, completion checklist, coding rules). Read it for anything not covered here — do not duplicate its content into this file.
+
+## What this is
+
+`sigmatcher` is a CLI that matches Java classes, methods, fields, and "exports" (arbitrary strings) across versions of an Android app by running YAML-defined signatures against decoded smali. It's reverse-engineering infrastructure: signatures are authored once and re-resolved as the target app changes between versions.
+
+## Environment
+
+- Python `>=3.10`. Use `uv` for everything — never invoke `pip` directly.
+- Bootstrap: `uv sync --locked --all-extras --dev`.
+- External binaries `rg` (ripgrep) and `apktool` are required for the full pipeline and for tests marked `external`.
+
+## Commands
+
+```bash
+uv run sigmatcher schema --output definitions.schema.json   # regen JSON schema for signature YAMLs
+
+uv run ruff check ./src                                     # lint
+uv run ruff format --check --diff ./src                     # format check
+uv run mypy .                                               # type check (strict, pydantic plugin)
+
+uv run pytest                                               # default: skips `external`-marked tests
+uv run pytest -m external                                   # run only the external-tool tests
+uv run pytest tests/unit/test_analysis.py::<test_name>      # single test
+```
+
+Default `pytest` config (`pyproject.toml`) sets `addopts = "-m 'not external'"`. CI runs additional type-checkers (`ty`, `pyrefly`, `basedpyright`) via `uv run --with ...`; see `AGENTS.md` for the exact invocations.
+
+## Architecture
+
+The pipeline is roughly: **unpack APK → grep smali → resolve definitions in dependency order → emit mapping**. Modules under `src/sigmatcher/`:
+
+- `cli.py` — Typer entry point. Subcommands: `analyze`, `convert`, `schema`, `cache`. `analyze` is the main flow; `convert` translates between output formats (`raw`, `enigma`, `jadx`, `legacy`); `schema` exports the Pydantic schema as JSON.
+- `definitions.py` — Pydantic models for YAML signature files (classes / methods / fields / exports + their `signatures`). Models are typically `frozen=True, extra="forbid"`. Holds merge logic for combining multiple signature files.
+- `analysis.py` — The analyzer. Builds a dependency graph over definitions (so macros like `${ConnectionManager.fields.socket.java}` can reference results from other definitions regardless of YAML order), topologically sorts it, then resolves each definition by running its signatures through `grep.py`. Macro resolution happens after sort.
+- `results.py` — Result models for matched classes/methods/fields/exports. These are what macros read properties off of.
+- `formats.py` — Read/write the different mapping output formats.
+- `cache.py` — Cache key derivation + serialization of analysis results (so re-running on the same unpacked APK is cheap).
+- `grep.py` — Thin wrapper around `rg` for count + search semantics used by signatures.
+- `unpack.py` — Wraps `apktool` to decode APK / `.apkm` / `.xapk` / split-APK directories; extracts the app version for `version_range` filtering.
+- `input_paths.py` — Normalizes the various supported input shapes.
+- `errors.py` — `SigmatcherError` hierarchy. Errors carry both a `short_message()` (user-facing) and `debug_message()` (verbose). Raise these — not bare `RuntimeError` — for expected matching/analysis failures.
+
+The signature file model is documented at length in `README.md` (macros, `version_range`, `count` ranges, `regex` vs `glob`). The Pydantic models in `definitions.py` are the source of truth; `definitions.schema.json` at the repo root is the generated artifact and must be regenerated via `uv run sigmatcher schema --output definitions.schema.json` when those models change.
+
+## Repo-specific conventions
+
+- **Absolute imports only** (`from sigmatcher.x import y`). Relative imports are banned by ruff's `flake8-tidy-imports` config.
+- Line length 120, Ruff defaults otherwise.
+- Strict typing: annotate params/returns, avoid `Any`. For 3.10/3.11 compatibility, use `typing_extensions` for `override` / `Self`.
+- Prefer `collections.abc` interfaces in type hints over concrete types.
+- Subprocess: explicit argv lists, never `shell=True`.
+- CLI: normal output to stdout, diagnostics/errors to stderr.
+- Pydantic models in this repo lean on `frozen=True` + `extra="forbid"`; use tuples for immutable definition collections, lists for mutable accumulators.
+- Analyzer child names use dotted form (e.g. `Class.methods.read`) — keep that convention when adding new analyzers.
+
+## Splitting work — commits, branches, worktrees
+
+Cleanliness over convenience. The goal is a history a reviewer can read top-to-bottom without rebuilding the story themselves.
+
+- **One logical change per commit.** Don't bundle a refactor with a bug fix with a dependency bump. If you find yourself writing "and also" in the commit subject, split it.
+- **Refactors before behavior changes.** When prep work and the real change land together, stage them as separate commits in that order — the diff for the behavior change should be small and obvious.
+- **Don't sneak in drive-by changes.** Unrelated formatting, rename, or cleanup belongs in its own commit (or its own PR). If touching it is unavoidable, call it out in the message.
+- **Branch per concern.** New branch off `main` for each independent piece of work; don't pile unrelated work onto a feature branch because it's already checked out.
+- **Use `git worktree` when contexts collide.** If you need to keep an in-progress branch checked out while doing review/hotfix work elsewhere, prefer `git worktree add ../sigmatcher-<topic> <branch>` over stashing. Avoids dirty trees and half-finished work getting accidentally amended into the wrong commit.
+- **Remove worktrees when done** (`git worktree remove …`) — don't leave stale checkouts lying around.
+- **Rebase, don't merge, for local cleanup.** Squash fixup commits and reorder before opening the PR so the public history is the curated version, not the working version. Never rewrite history that's already been pushed and reviewed.
+- **Commit messages explain *why*.** The diff already shows *what*. One-sentence subject in the imperative; body only when the reasoning isn't obvious from the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,39 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+`sigmatcher` is a CLI that matches Java classes, methods, fields, and "exports" (arbitrary
+strings) across versions of an Android app by running YAML-defined signatures against
+decoded smali. It's reverse-engineering infrastructure: signatures are authored once and
+re-resolved as the target app changes between versions.
 
-A companion `AGENTS.md` at the repo root has a more detailed agent-oriented breakdown (commands, completion checklist, coding rules). Read it for anything not covered here — do not duplicate its content into this file.
+For commands, environment setup, the architecture map, and the coding rules (absolute
+imports, strict typing, Pydantic conventions, subprocess argv-only, etc.), read
+[`AGENTS.md`](AGENTS.md). The rules in there apply equally to Claude Code sessions. The
+README has the user-facing signature-file documentation.
 
-## What this is
-
-`sigmatcher` is a CLI that matches Java classes, methods, fields, and "exports" (arbitrary strings) across versions of an Android app by running YAML-defined signatures against decoded smali. It's reverse-engineering infrastructure: signatures are authored once and re-resolved as the target app changes between versions.
-
-## Environment
-
-- Python `>=3.10`. Use `uv` for everything — never invoke `pip` directly.
-- Bootstrap: `uv sync --locked --all-extras --dev`.
-- External binaries `rg` (ripgrep) and `apktool` are required for the full pipeline and for tests marked `external`.
-
-## Commands
-
-```bash
-uv run sigmatcher schema --output definitions.schema.json   # regen JSON schema for signature YAMLs
-
-uv run ruff check ./src                                     # lint
-uv run ruff format --check --diff ./src                     # format check
-uv run mypy .                                               # type check (strict, pydantic plugin)
-
-uv run pytest                                               # default: skips `external`-marked tests
-uv run pytest -m external                                   # run only the external-tool tests
-uv run pytest tests/unit/test_analysis.py::<test_name>      # single test
-```
-
-Default `pytest` config (`pyproject.toml`) sets `addopts = "-m 'not external'"`. CI runs additional type-checkers (`ty`, `pyrefly`, `basedpyright`) via `uv run --with ...`; see `AGENTS.md` for the exact invocations.
-
-## Architecture
-
-The pipeline is roughly: **unpack APK → grep smali → resolve definitions in dependency order → emit mapping**. Modules under `src/sigmatcher/`:
-
-- `cli.py` — Typer entry point. Subcommands: `analyze`, `convert`, `schema`, `cache`. `analyze` is the main flow; `convert` translates between output formats (`raw`, `enigma`, `jadx`, `legacy`); `schema` exports the Pydantic schema as JSON.
-- `definitions.py` — Pydantic models for YAML signature files (classes / methods / fields / exports + their `signatures`). Models are typically `frozen=True, extra="forbid"`. Holds merge logic for combining multiple signature files.
-- `analysis.py` — The analyzer. Builds a dependency graph over definitions (so macros like `${ConnectionManager.fields.socket.java}` can reference results from other definitions regardless of YAML order), topologically sorts it, then resolves each definition by running its signatures through `grep.py`. Macro resolution happens after sort.
-- `results.py` — Result models for matched classes/methods/fields/exports. These are what macros read properties off of.
-- `formats.py` — Read/write the different mapping output formats.
-- `cache.py` — Cache key derivation + serialization of analysis results (so re-running on the same unpacked APK is cheap).
-- `grep.py` — Thin wrapper around `rg` for count + search semantics used by signatures.
-- `unpack.py` — Wraps `apktool` to decode APK / `.apkm` / `.xapk` / split-APK directories; extracts the app version for `version_range` filtering.
-- `input_paths.py` — Normalizes the various supported input shapes.
-- `errors.py` — `SigmatcherError` hierarchy. Errors carry both a `short_message()` (user-facing) and `debug_message()` (verbose). Raise these — not bare `RuntimeError` — for expected matching/analysis failures.
-
-The signature file model is documented at length in `README.md` (macros, `version_range`, `count` ranges, `regex` vs `glob`). The Pydantic models in `definitions.py` are the source of truth; `definitions.schema.json` at the repo root is the generated artifact and must be regenerated via `uv run sigmatcher schema --output definitions.schema.json` when those models change.
-
-## Repo-specific conventions
-
-- **Absolute imports only** (`from sigmatcher.x import y`). Relative imports are banned by ruff's `flake8-tidy-imports` config.
-- Line length 120, Ruff defaults otherwise.
-- Strict typing: annotate params/returns, avoid `Any`. For 3.10/3.11 compatibility, use `typing_extensions` for `override` / `Self`.
-- Prefer `collections.abc` interfaces in type hints over concrete types.
-- Subprocess: explicit argv lists, never `shell=True`.
-- CLI: normal output to stdout, diagnostics/errors to stderr.
-- Pydantic models in this repo lean on `frozen=True` + `extra="forbid"`; use tuples for immutable definition collections, lists for mutable accumulators.
-- Analyzer child names use dotted form (e.g. `Class.methods.read`) — keep that convention when adding new analyzers.
+This file only holds Claude-Code-specific guidance not covered there.
 
 ## Splitting work — commits, branches, worktrees
 
-Cleanliness over convenience. The goal is a history a reviewer can read top-to-bottom without rebuilding the story themselves.
+Cleanliness over convenience. The goal is a history a reviewer can read top-to-bottom
+without rebuilding the story themselves.
 
-- **One logical change per commit.** Don't bundle a refactor with a bug fix with a dependency bump. If you find yourself writing "and also" in the commit subject, split it.
-- **Refactors before behavior changes.** When prep work and the real change land together, stage them as separate commits in that order — the diff for the behavior change should be small and obvious.
-- **Don't sneak in drive-by changes.** Unrelated formatting, rename, or cleanup belongs in its own commit (or its own PR). If touching it is unavoidable, call it out in the message.
-- **Branch per concern.** New branch off `main` for each independent piece of work; don't pile unrelated work onto a feature branch because it's already checked out.
-- **Use `git worktree` when contexts collide.** If you need to keep an in-progress branch checked out while doing review/hotfix work elsewhere, prefer `git worktree add ../sigmatcher-<topic> <branch>` over stashing. Avoids dirty trees and half-finished work getting accidentally amended into the wrong commit.
-- **Remove worktrees when done** (`git worktree remove …`) — don't leave stale checkouts lying around.
-- **Rebase, don't merge, for local cleanup.** Squash fixup commits and reorder before opening the PR so the public history is the curated version, not the working version. Never rewrite history that's already been pushed and reviewed.
-- **Commit messages explain *why*.** The diff already shows *what*. One-sentence subject in the imperative; body only when the reasoning isn't obvious from the code.
+- **One logical change per commit.** Don't bundle a refactor with a bug fix with a
+  dependency bump. If you find yourself writing "and also" in the commit subject, split it.
+- **Refactors before behavior changes.** When prep work and the real change land together,
+  stage them as separate commits in that order — the diff for the behavior change should
+  be small and obvious.
+- **Don't sneak in drive-by changes.** Unrelated formatting, rename, or cleanup belongs in
+  its own commit (or its own PR). If touching it is unavoidable, call it out in the message.
+- **Branch per concern.** New branch off `main` for each independent piece of work; don't
+  pile unrelated work onto a feature branch because it's already checked out.
+- **Use `git worktree` when contexts collide.** If you need to keep an in-progress branch
+  checked out while doing review/hotfix work elsewhere, prefer
+  `git worktree add ../sigmatcher-<topic> <branch>` over stashing. Avoids dirty trees and
+  half-finished work getting accidentally amended into the wrong commit.
+- **Remove worktrees when done** (`git worktree remove …`) — don't leave stale checkouts
+  lying around.
+- **Rebase, don't merge, for local cleanup.** Squash fixup commits and reorder before
+  opening the PR so the public history is the curated version, not the working version.
+  Never rewrite history that's already been pushed and reviewed.
+- **Commit messages explain *why*.** The diff already shows *what*. One-sentence subject
+  in the imperative; body only when the reasoning isn't obvious from the code.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ invaluable resource for long-running reverse engineering projects.
   - [Signature File JSON Schema](#signature-file-json-schema)
   - [Structure of a Signature File](#structure-of-a-signature-file)
   - [Using Macros in Signatures](#using-macros-in-signatures)
+  - [Dynamic Class Names](#dynamic-class-names)
 - [License](#license)
 
 ## Installation
@@ -250,6 +251,46 @@ In this example:
 - If a macro references a result that cannot be matched, the signature will fail to match
 - Use the `java` property when you need the complete Java/Smali representation of a class, method, or field
 - Macros work with both `regex` and `glob` signature types
+
+### Dynamic Class Names
+
+Normally a `ClassDefinition` declares the human-readable class `name` up front and `sigmatcher`
+finds the obfuscated class it maps to. Sometimes the readable name is not known in advance but
+is embedded in the obfuscated class itself — for example, a class whose `toString()` returns
+a literal containing its original name:
+
+```smali
+const-string v0, "ConnectionManager{state=connected"
+```
+
+In that case you can opt in to **dynamic class name** capture: declare a placeholder identifier
+as the YAML `name`, set `dynamic_name: true`, and add a `(?P<class_name>...)` named group in one
+of the signatures. The captured substring becomes the readable name in all output mapping
+formats; the placeholder `name` is still used as the identifier for macro references, caching,
+and the dependency graph.
+
+```yaml
+# $schema: ./definitions.schema.json
+# yaml-language-server: $schema=./definitions.schema.json
+
+- name: "UnknownToStringClass"
+  dynamic_name: true
+  signatures:
+    - signature: '"(?P<class_name>\w+)\{state='
+      type: regex
+      count: 1
+```
+
+Notes:
+
+- The placeholder `name` (`UnknownToStringClass` above) is what other definitions reference via
+  macros (e.g. `${UnknownToStringClass.java}`), and what appears in error messages.
+- If a `dynamic_name: true` definition's signatures match the file but no `(?P<class_name>...)`
+  capture is produced, the match fails (`NoMatchesError`).
+- If the capture yields multiple distinct values from the matched smali, the match fails
+  (`TooManyMatchesError`). Tighten the regex to disambiguate.
+- The opt-in flag is required: putting a `(?P<class_name>...)` group on a class signature
+  without setting `dynamic_name: true` is a validation error, to prevent silent activation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ Notes:
   capture is produced, the match fails (`NoMatchesError`).
 - If the capture yields multiple distinct values from the matched smali, the match fails
   (`TooManyMatchesError`). Tighten the regex to disambiguate.
+- Captures are compared after `str.strip()`: leading/trailing whitespace is treated as
+  insignificant, and a capture that is empty or whitespace-only is dropped. Two
+  occurrences that differ only in ambient whitespace (e.g. `" Foo"` and `"Foo"`) collapse
+  to one value; if you need to distinguish them, narrow the regex so the capture group
+  cannot pick up surrounding whitespace.
+- A `dynamic_name: true` definition must have at least one signature carrying the
+  `(?P<class_name>...)` group applicable to the current app version. If a `version_range`
+  filters the only capturing signature out, analysis raises a dedicated
+  `MissingClassNameGroupError` pointing at the definition and version.
 - The opt-in flag is required: putting a `(?P<class_name>...)` group on a class signature
   without setting `dynamic_name: true` is a validation error, to prevent silent activation.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ invaluable resource for long-running reverse engineering projects.
   - [Signature File JSON Schema](#signature-file-json-schema)
   - [Structure of a Signature File](#structure-of-a-signature-file)
   - [Using Macros in Signatures](#using-macros-in-signatures)
-  - [Dynamic Class Names](#dynamic-class-names)
+  - [Dynamic Definitions](#dynamic-definitions)
 - [License](#license)
 
 ## Installation
@@ -252,68 +252,89 @@ In this example:
 - Use the `java` property when you need the complete Java/Smali representation of a class, method, or field
 - Macros work with both `regex` and `glob` signature types
 
-### Dynamic Class Names
+### Dynamic Definitions
 
-Normally a `ClassDefinition` declares the human-readable class `name` up front and `sigmatcher`
-finds the obfuscated class it maps to. Sometimes the readable name is not known in advance but
-is embedded in the obfuscated class itself — for example, a class whose `toString()` returns
-a literal containing its original name:
+Normally a definition declares its human-readable `name` up front and `sigmatcher` finds the
+obfuscated class / method / field / export it maps to. Sometimes the readable name is not known
+in advance but is embedded in the smali itself — for example, a class whose `toString()`
+returns a literal containing its original name, or an auto-generated method present across
+many classes:
 
 ```smali
 const-string v0, "ConnectionManager{state=connected"
 ```
 
-In that case you can opt in to **dynamic class name** capture: declare a placeholder identifier
-as the YAML `name`, set `dynamic_name: true`, and add a `(?P<class_name>...)` named group in one
-of the signatures. The captured substring becomes the result's `original.name` and is what each
-output mapping format uses for the readable class name — see the format-by-format breakdown
-below. The placeholder `name` is still used as the identifier for macro references, caching,
-and the dependency graph, and remains the dictionary key in `raw` output.
+In that case you can opt in to **dynamic definitions**. A dynamic definition is a single
+signature that matches **0 or more entities** in the corpus; each match becomes its own result,
+with the readable identifier captured from a named regex group in the signature.
 
-How the captured name surfaces per output format:
+Dynamic definitions are available on every axis:
 
-- `raw`: the top-level JSON key for the class is the placeholder `name` (the analyzer
-  identifier, e.g. `UnknownToStringClass`); the captured value appears inside the entry as
-  `original.name`.
-- `legacy`: the top-level JSON key for the class is the captured `original.name` directly.
-- `enigma`: each `CLASS <new_java> <original_java>` line embeds the captured name into
-  `<original_java>` via `original.to_java_representation()`, so it is prefixed by the
-  definition's `package` (defaulting to the obfuscated class's package when `package` is
-  unset).
-- `jadx`: each rename uses `original.to_full_name()` as `newName`, again prefixed by
-  `package`.
+| Axis | Top-level `type:` | Capture group | Resulting result type |
+|------|-------------------|---------------|-----------------------|
+| Class | `class` (default) | `(?P<class_name>...)` | `MatchedClass` |
+| Method | `method` | `(?P<method_name>...)` | `MatchedMethod` |
+| Field | `field` | `(?P<field_name>...)` | `MatchedField` |
+| Export | `export` | `(?P<export_name>...)` | `MatchedExport` |
+
+A bare list of definitions without a `type:` field is parsed as the historical
+`ClassDefinition` shape — the `type` discriminator defaults to `class`.
 
 ```yaml
 # $schema: ./definitions.schema.json
 # yaml-language-server: $schema=./definitions.schema.json
 
+# Dynamic class: one MatchedClass per smali file matching the signature.
 - name: "UnknownToStringClass"
   dynamic_name: true
   signatures:
     - signature: '"(?P<class_name>\w+)\{state='
       type: regex
       count: 1
+
+# Dynamic top-level method: scans the whole corpus and emits one MatchedMethod per match.
+- type: method
+  name: "AutoToString"
+  dynamic_name: true
+  signatures:
+    - signature: 'const-string v\d+, "(?P<method_name>\w+_TOKEN)"'
+      type: regex
+      count: "1-100"
 ```
 
-Notes:
+#### Output format keying
 
-- The placeholder `name` (`UnknownToStringClass` above) is what other definitions reference via
-  macros (e.g. `${UnknownToStringClass.java}`), and what appears in error messages.
-- If a `dynamic_name: true` definition's signatures match the file but no `(?P<class_name>...)`
-  capture is produced, the match fails (`NoMatchesError`).
-- If the capture yields multiple distinct values from the matched smali, the match fails
-  (`TooManyMatchesError`). Tighten the regex to disambiguate.
-- Captures are compared after `str.strip()`: leading/trailing whitespace is treated as
-  insignificant, and a capture that is empty or whitespace-only is dropped. Two
-  occurrences that differ only in ambient whitespace (e.g. `" Foo"` and `"Foo"`) collapse
-  to one value; if you need to distinguish them, narrow the regex so the capture group
-  cannot pick up surrounding whitespace.
-- A `dynamic_name: true` definition must have at least one signature carrying the
-  `(?P<class_name>...)` group applicable to the current app version. If a `version_range`
-  filters the only capturing signature out, analysis raises a dedicated
-  `MissingClassNameGroupError` pointing at the definition and version.
-- The opt-in flag is required: putting a `(?P<class_name>...)` group on a class signature
-  without setting `dynamic_name: true` is a validation error, to prevent silent activation.
+Output formats key each result by the **captured** `original.name`, not the placeholder name
+declared in YAML. The placeholder name is still used for macros, caching, and the dependency
+graph — but `raw`, `legacy`, `enigma`, and `jadx` all index by what was captured.
+
+For top-level dynamic method / field / export definitions, the matched entities are folded
+under a **synthesized holder class entry** keyed by the obfuscated class they were found in.
+This keeps the "one MatchedClass per top-level key" output contract intact.
+
+#### Semantic rules
+
+- **0 matches is not an error.** A dynamic definition whose signature matches nothing yields
+  an empty list, not a `NoMatchesError`. (Static definitions still error on 0 matches.)
+- **Each capture becomes its own result.** If a dynamic class def matches three smali files
+  with distinct captures `Alpha`, `Beta`, `Gamma`, the result list has three `MatchedClass`
+  entries.
+- **Macros cannot point at dynamic definitions.** A `${Foo.java}` macro that references a
+  dynamic definition is a hard load-time error (`MacroPointsToDynamicError`) — dynamic defs
+  emit 0+ matches and cannot resolve to a single value.
+- **Static child + dynamic parent → all-or-nothing.** When a dynamic class def matches N
+  classes, each nested static child analyzer runs N times. If the child signature fails for
+  any one parent match, the entire child result is a single `SigmatcherError` rather than a
+  mixed list of successes and errors.
+- **Captured-name collisions are hard errors.** If two definitions produce results whose
+  `original.name` collide, output formatting raises `DuplicateCapturedNameError`. Tighten one
+  of the signatures to disambiguate.
+- **Captures are stripped.** `" Foo"` and `"Foo"` collapse to a single readable name `Foo`;
+  empty/whitespace-only captures are dropped.
+- **Version filtering still applies.** If `version_range` filters out the only signature with
+  the axis-specific capture group, analysis raises `MissingDynamicCaptureGroupError`. The
+  opt-in `dynamic_name: true` flag is required: putting `(?P<class_name>...)` (etc.) on a
+  signature without it is a validation error.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -265,9 +265,23 @@ const-string v0, "ConnectionManager{state=connected"
 
 In that case you can opt in to **dynamic class name** capture: declare a placeholder identifier
 as the YAML `name`, set `dynamic_name: true`, and add a `(?P<class_name>...)` named group in one
-of the signatures. The captured substring becomes the readable name in all output mapping
-formats; the placeholder `name` is still used as the identifier for macro references, caching,
-and the dependency graph.
+of the signatures. The captured substring becomes the result's `original.name` and is what each
+output mapping format uses for the readable class name — see the format-by-format breakdown
+below. The placeholder `name` is still used as the identifier for macro references, caching,
+and the dependency graph, and remains the dictionary key in `raw` output.
+
+How the captured name surfaces per output format:
+
+- `raw`: the top-level JSON key for the class is the placeholder `name` (the analyzer
+  identifier, e.g. `UnknownToStringClass`); the captured value appears inside the entry as
+  `original.name`.
+- `legacy`: the top-level JSON key for the class is the captured `original.name` directly.
+- `enigma`: each `CLASS <new_java> <original_java>` line embeds the captured name into
+  `<original_java>` via `original.to_java_representation()`, so it is prefixed by the
+  definition's `package` (defaulting to the obfuscated class's package when `package` is
+  unset).
+- `jadx`: each rename uses `original.to_full_name()` as `newName`, again prefixed by
+  `package`.
 
 ```yaml
 # $schema: ./definitions.schema.json

--- a/definitions.schema.json
+++ b/definitions.schema.json
@@ -59,6 +59,13 @@
           "title": "Exclude",
           "type": "boolean"
         },
+        "type": {
+          "const": "class",
+          "default": "class",
+          "description": "The top-level definition kind. Defaults to \"class\" so existing signature\nfiles without a `type:` discriminator still validate.",
+          "title": "Type",
+          "type": "string"
+        },
         "package": {
           "anyOf": [
             {
@@ -428,6 +435,249 @@
       "title": "RegexSignature",
       "type": "object"
     },
+    "TopLevelExportDefinition": {
+      "additionalProperties": false,
+      "description": "A top-level export definition. Scans the entire smali corpus and produces\nzero or more MatchedExport results. The readable name comes from a\n`(?P<export_name>...)` capture group when `dynamic_name` is true.",
+      "properties": {
+        "name": {
+          "description": "The name of the definition, i.e. the class, method, field, or export name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "signatures": {
+          "description": "A list of signatures that define the definition.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "glob": "#/$defs/GlobSignature",
+                "regex": "#/$defs/RegexSignature",
+                "treesitter": "#/$defs/TreeSitterSignature"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RegexSignature"
+              },
+              {
+                "$ref": "#/$defs/GlobSignature"
+              },
+              {
+                "$ref": "#/$defs/TreeSitterSignature"
+              }
+            ]
+          },
+          "title": "Signatures",
+          "type": "array"
+        },
+        "version_range": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The version range in which the definition is valid.",
+          "title": "Version Range"
+        },
+        "exclude": {
+          "default": false,
+          "description": "Exclude this definition from the final results.\nThis could be useful if the definition is only used to find something else using a macro",
+          "title": "Exclude",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "export",
+          "default": "export",
+          "description": "The top-level definition kind.",
+          "title": "Type",
+          "type": "string"
+        },
+        "dynamic_name": {
+          "default": false,
+          "description": "If true, capture the readable export name from a `(?P<export_name>...)` named group.",
+          "title": "Dynamic Name",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "signatures"
+      ],
+      "title": "TopLevelExportDefinition",
+      "type": "object"
+    },
+    "TopLevelFieldDefinition": {
+      "additionalProperties": false,
+      "description": "A top-level field definition. Scans the entire smali corpus and produces\nzero or more MatchedField results. The readable name comes from a\n`(?P<field_name>...)` capture group when `dynamic_name` is true.",
+      "properties": {
+        "name": {
+          "description": "The name of the definition, i.e. the class, method, field, or export name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "signatures": {
+          "description": "A list of signatures that define the definition.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "glob": "#/$defs/GlobSignature",
+                "regex": "#/$defs/RegexSignature",
+                "treesitter": "#/$defs/TreeSitterSignature"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RegexSignature"
+              },
+              {
+                "$ref": "#/$defs/GlobSignature"
+              },
+              {
+                "$ref": "#/$defs/TreeSitterSignature"
+              }
+            ]
+          },
+          "title": "Signatures",
+          "type": "array"
+        },
+        "version_range": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The version range in which the definition is valid.",
+          "title": "Version Range"
+        },
+        "exclude": {
+          "default": false,
+          "description": "Exclude this definition from the final results.\nThis could be useful if the definition is only used to find something else using a macro",
+          "title": "Exclude",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "field",
+          "default": "field",
+          "description": "The top-level definition kind.",
+          "title": "Type",
+          "type": "string"
+        },
+        "dynamic_name": {
+          "default": false,
+          "description": "If true, capture the readable field name from a `(?P<field_name>...)` named group.",
+          "title": "Dynamic Name",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "signatures"
+      ],
+      "title": "TopLevelFieldDefinition",
+      "type": "object"
+    },
+    "TopLevelMethodDefinition": {
+      "additionalProperties": false,
+      "description": "A top-level method definition. Scans the entire smali corpus and produces\nzero or more MatchedMethod results, one per occurrence. The readable name comes\nfrom a `(?P<method_name>...)` capture group when `dynamic_name` is true.",
+      "properties": {
+        "name": {
+          "description": "The name of the definition, i.e. the class, method, field, or export name.",
+          "title": "Name",
+          "type": "string"
+        },
+        "signatures": {
+          "description": "A list of signatures that define the definition.",
+          "items": {
+            "discriminator": {
+              "mapping": {
+                "glob": "#/$defs/GlobSignature",
+                "regex": "#/$defs/RegexSignature",
+                "treesitter": "#/$defs/TreeSitterSignature"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/RegexSignature"
+              },
+              {
+                "$ref": "#/$defs/GlobSignature"
+              },
+              {
+                "$ref": "#/$defs/TreeSitterSignature"
+              }
+            ]
+          },
+          "title": "Signatures",
+          "type": "array"
+        },
+        "version_range": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The version range in which the definition is valid.",
+          "title": "Version Range"
+        },
+        "exclude": {
+          "default": false,
+          "description": "Exclude this definition from the final results.\nThis could be useful if the definition is only used to find something else using a macro",
+          "title": "Exclude",
+          "type": "boolean"
+        },
+        "type": {
+          "const": "method",
+          "default": "method",
+          "description": "The top-level definition kind.",
+          "title": "Type",
+          "type": "string"
+        },
+        "dynamic_name": {
+          "default": false,
+          "description": "If true, capture the readable method name from a `(?P<method_name>...)` named group.",
+          "title": "Dynamic Name",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name",
+        "signatures"
+      ],
+      "title": "TopLevelMethodDefinition",
+      "type": "object"
+    },
     "TreeSitterSignature": {
       "additionalProperties": false,
       "properties": {
@@ -483,7 +733,20 @@
     }
   },
   "items": {
-    "$ref": "#/$defs/ClassDefinition"
+    "oneOf": [
+      {
+        "$ref": "#/$defs/ClassDefinition"
+      },
+      {
+        "$ref": "#/$defs/TopLevelMethodDefinition"
+      },
+      {
+        "$ref": "#/$defs/TopLevelFieldDefinition"
+      },
+      {
+        "$ref": "#/$defs/TopLevelExportDefinition"
+      }
+    ]
   },
   "type": "array",
   "title": "Sigmatcher's Definitions",

--- a/definitions.schema.json
+++ b/definitions.schema.json
@@ -98,6 +98,12 @@
           },
           "title": "Exports",
           "type": "array"
+        },
+        "dynamic_name": {
+          "default": false,
+          "description": "If true, capture the readable class name from a `(?P<class_name>...)` named group\nin one of the signatures. The YAML `name` is the placeholder used for macros,\ncaching, and dependency-graph identity; the captured value becomes the readable\n`original.name` in the result and is what shows up in output mapping formats.",
+          "title": "Dynamic Name",
+          "type": "boolean"
         }
       },
       "required": [

--- a/definitions.schema.json
+++ b/definitions.schema.json
@@ -437,7 +437,7 @@
     },
     "TopLevelExportDefinition": {
       "additionalProperties": false,
-      "description": "A top-level export definition. Scans the entire smali corpus and produces\nzero or more MatchedExport results. The readable name comes from a\n`(?P<export_name>...)` capture group when `dynamic_name` is true.",
+      "description": "A top-level export definition. Scans the entire smali corpus and produces\nzero or more MatchedExport results. The readable name comes from a\n`(?P<export_name>...)` capture group; `dynamic_name` must be true.",
       "properties": {
         "name": {
           "description": "The name of the definition, i.e. the class, method, field, or export name.",
@@ -504,7 +504,7 @@
         },
         "dynamic_name": {
           "default": false,
-          "description": "If true, capture the readable export name from a `(?P<export_name>...)` named group.",
+          "description": "If true, capture the readable export name from a `(?P<export_name>...)` named group.\nTop-level export definitions must set this to true \u2014 see the validator below.",
           "title": "Dynamic Name",
           "type": "boolean"
         }
@@ -518,7 +518,7 @@
     },
     "TopLevelFieldDefinition": {
       "additionalProperties": false,
-      "description": "A top-level field definition. Scans the entire smali corpus and produces\nzero or more MatchedField results. The readable name comes from a\n`(?P<field_name>...)` capture group when `dynamic_name` is true.",
+      "description": "A top-level field definition. Scans the entire smali corpus and produces\nzero or more MatchedField results. The readable name comes from a\n`(?P<field_name>...)` capture group; `dynamic_name` must be true.",
       "properties": {
         "name": {
           "description": "The name of the definition, i.e. the class, method, field, or export name.",
@@ -585,7 +585,7 @@
         },
         "dynamic_name": {
           "default": false,
-          "description": "If true, capture the readable field name from a `(?P<field_name>...)` named group.",
+          "description": "If true, capture the readable field name from a `(?P<field_name>...)` named group.\nTop-level field definitions must set this to true \u2014 see the validator below.",
           "title": "Dynamic Name",
           "type": "boolean"
         }
@@ -599,7 +599,7 @@
     },
     "TopLevelMethodDefinition": {
       "additionalProperties": false,
-      "description": "A top-level method definition. Scans the entire smali corpus and produces\nzero or more MatchedMethod results, one per occurrence. The readable name comes\nfrom a `(?P<method_name>...)` capture group when `dynamic_name` is true.",
+      "description": "A top-level method definition. Scans the entire smali corpus and produces\nzero or more MatchedMethod results, one per occurrence. The readable name comes\nfrom a `(?P<method_name>...)` capture group; `dynamic_name` must be true.",
       "properties": {
         "name": {
           "description": "The name of the definition, i.e. the class, method, field, or export name.",
@@ -666,7 +666,7 @@
         },
         "dynamic_name": {
           "default": false,
-          "description": "If true, capture the readable method name from a `(?P<method_name>...)` named group.",
+          "description": "If true, capture the readable method name from a `(?P<method_name>...)` named group.\nTop-level method definitions must set this to true \u2014 see the validator below.",
           "title": "Dynamic Name",
           "type": "boolean"
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sigmatcher"
-version = "1.9.2"
+version = "2.0.0"
 authors = [{ name = "Ori Perry", email = "oriori1703@gmail.com" }]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -140,6 +140,15 @@ class Analyzer(ABC):
     definition: Definition
     app_version: str | None
 
+    # Structural marker used by output formatting to decide whether an analyzer's
+    # results are nested children (already attached to a parent MatchedClass) or
+    # top-level entries (must be emitted in their own right). Overridden to True
+    # on `ChildAnalyzer`. Routing on this marker — rather than substring-matching
+    # the dotted analyzer name — keeps user-authored definitions whose `name`
+    # happens to contain ".methods."/".fields."/".exports." from being silently
+    # mis-routed.
+    is_child_analyzer: ClassVar[bool] = False
+
     @abstractmethod
     def analyze(self, results: ResultsMapType) -> list[Result]:
         pass
@@ -329,6 +338,8 @@ class DynamicClassAnalyzer(ClassAnalyzer):
 @dataclasses.dataclass(frozen=True)
 class ChildAnalyzer(Analyzer, ABC):
     parent: ClassAnalyzer
+
+    is_child_analyzer: ClassVar[bool] = True
 
     @override
     def _get_dependencies(self) -> set[str]:
@@ -790,6 +801,23 @@ def create_analyzers(
             name_to_analyzer[analyzer.name] = analyzer
 
     return name_to_analyzer
+
+
+def get_child_analyzer_names(
+    definitions: Sequence[TopLevelDefinition], search_root: Path, app_version: str | None
+) -> set[str]:
+    """Return the names of analyzers whose results are nested children of a class.
+
+    Output formatting (see `formats.flatten_analyzer_results`) needs to know which
+    `results` entries are nested children — those are already attached to their
+    parent `MatchedClass` and must not be re-routed into a synthesized holder.
+    Routing on this set, derived from the structural `is_child_analyzer` marker,
+    avoids substring-matching the analyzer name (which mis-classified user-authored
+    top-level defs whose YAML name happened to contain `.methods.`/`.fields.`/
+    `.exports.`).
+    """
+    name_to_analyzer = create_analyzers(definitions, search_root, app_version)
+    return {name for name, analyzer in name_to_analyzer.items() if analyzer.is_child_analyzer}
 
 
 def sort_analyzers(name_to_analyzer: dict[str, Analyzer], results: ResultsMapType) -> Iterable[str]:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -455,7 +455,9 @@ class FieldAnalyzer(ChildAnalyzer):
             raise NoSignaturesError(self.name)
         if len(signatures) > 1:
             raise TooManySignaturesError(self.name, signatures)
-        signature = signatures[0]
+        # `next(iter(...))` keeps the type narrow without indexing; basedpyright does
+        # not propagate the empty-truthiness narrowing through to `signatures[0]`.
+        signature = next(iter(signatures))
 
         raw_class = parent_class_result.smali_file.read_text()
         captured_names = signature.capture(raw_class)
@@ -529,7 +531,7 @@ class ExportAnalyzer(ChildAnalyzer):
             raise NoSignaturesError(self.name)
         if len(signatures) > 1:
             raise TooManySignaturesError(self.name, signatures)
-        signature = signatures[0]
+        signature = next(iter(signatures))
 
         raw_class = parent_class_result.smali_file.read_text()
         captured_names = signature.capture(raw_class)

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -201,40 +201,42 @@ class ClassAnalyzer(Analyzer):
 
         readable_name = self.definition.name
         if self.definition.dynamic_name:
-            # The model-level validator only sees the full signature tuple. The runtime
-            # subset is version-filtered, so a definition with a non-capturing signature
-            # for old versions and a capturing one for new versions can pass validation
-            # yet have no class_name group applicable to the current run. Surface this
-            # as a dedicated error instead of the misleading NoMatchesError that the
-            # capture loop would otherwise raise.
-            if not any(
-                isinstance(signature, BaseRegexSignature) and signature.has_class_name_group()
-                for signature in signatures
-            ):
-                raise MissingClassNameGroupError(self.name, self.app_version)
-
-            raw_class = match.read_text()
-            captures: set[str] = set()
-            for signature in signatures:
-                if isinstance(signature, BaseRegexSignature):
-                    captures.update(signature.capture_class_name(raw_class))
-            # Surrounding whitespace in a capture is treated as insignificant: " Foo"
-            # and "Foo" collapse to "Foo", and a capture that is empty / whitespace-only
-            # is dropped. This matches the realistic smali case where a leading space
-            # may end up inside a tolerant regex group, and prevents spurious
-            # TooManyMatchesError when the same readable name is captured twice with
-            # different ambient whitespace. See the README "Dynamic Class Names" section.
-            captures = {c.strip() for c in captures if c and c.strip()}
-            if not captures:
-                raise NoMatchesError(self.name, tuple(signatures))
-            if len(captures) > 1:
-                raise TooManyMatchesError[str](self.name, tuple(signatures), captures)
-            readable_name = next(iter(captures))
+            readable_name = self._capture_dynamic_name(match, signatures)
 
         original_class = Class(name=readable_name, package=self.definition.package or new_class.package)
         return MatchedClass(
             original=original_class, new=new_class, smali_file=match, matched_methods=[], matched_fields=[], exports=[]
         )
+
+    def _capture_dynamic_name(self, match: Path, signatures: Sequence[Signature]) -> str:
+        # The model-level validator only sees the full signature tuple. The runtime
+        # subset is version-filtered, so a definition with a non-capturing signature
+        # for old versions and a capturing one for new versions can pass validation
+        # yet have no class_name group applicable to the current run. Surface this
+        # as a dedicated error instead of the misleading NoMatchesError that the
+        # capture loop would otherwise raise.
+        if not any(
+            isinstance(signature, BaseRegexSignature) and signature.has_class_name_group() for signature in signatures
+        ):
+            raise MissingClassNameGroupError(self.name, self.app_version)
+
+        raw_class = match.read_text()
+        captures: set[str] = set()
+        for signature in signatures:
+            if isinstance(signature, BaseRegexSignature):
+                captures.update(signature.capture_class_name(raw_class))
+        # Surrounding whitespace in a capture is treated as insignificant: " Foo"
+        # and "Foo" collapse to "Foo", and a capture that is empty / whitespace-only
+        # is dropped. This matches the realistic smali case where a leading space
+        # may end up inside a tolerant regex group, and prevents spurious
+        # TooManyMatchesError when the same readable name is captured twice with
+        # different ambient whitespace. See the README "Dynamic Class Names" section.
+        captures = {c.strip() for c in captures if c and c.strip()}
+        if not captures:
+            raise NoMatchesError(self.name, tuple(signatures))
+        if len(captures) > 1:
+            raise TooManyMatchesError[str](self.name, tuple(signatures), captures)
+        return next(iter(captures))
 
     @override
     def from_cache(self, cached_result: Result, results: dict[str, Result | SigmatcherError]) -> MatchedClass:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -275,47 +275,39 @@ class StaticClassAnalyzer(ClassAnalyzer):
 
 @dataclasses.dataclass(frozen=True)
 class DynamicClassAnalyzer(ClassAnalyzer):
-    """A class analyzer whose `original.name` is captured from `(?P<class_name>...)`."""
+    """A class analyzer whose `original.name` is captured from `(?P<class_name>...)`.
+
+    Emits zero or more MatchedClass entries — one per (matching smali file, captured
+    readable name) pair. Zero matches is a legitimate empty result list, not an error.
+    """
 
     @override
     def analyze(self, results: ResultsMapType) -> list[Result]:
         signatures, class_matches = self._find_class_matches(results)
-        self.check_match_count(class_matches, tuple(signatures))
-        match = next(iter(class_matches))
-        readable_name = self._capture_dynamic_name(match, signatures)
-        return [self._build_matched_class(match, readable_name)]
-
-    def _capture_dynamic_name(self, match: Path, signatures: Sequence[Signature]) -> str:
-        # The model-level validator only sees the full signature tuple. The runtime
-        # subset is version-filtered, so a definition with a non-capturing signature
-        # for old versions and a capturing one for new versions can pass validation
-        # yet have no class_name group applicable to the current run. Surface this
-        # as a dedicated error instead of the misleading NoMatchesError that the
-        # capture loop would otherwise raise.
         if not any(
             isinstance(signature, BaseRegexSignature) and signature.has_class_name_group() for signature in signatures
         ):
+            # The model-level validator only sees the full signature tuple. The runtime
+            # subset is version-filtered; a definition with a non-capturing signature for
+            # old versions and a capturing one for new versions can pass validation yet
+            # have no class_name group applicable to the current run. Surface that as a
+            # dedicated error instead of silently returning an empty match list.
             raise MissingClassNameGroupError(self.name, self.app_version)
 
-        raw_class = match.read_text()
-        captures: set[str] = set()
-        for signature in signatures:
-            if isinstance(signature, BaseRegexSignature):
-                captures.update(signature.capture_class_name(raw_class))
-        # Surrounding whitespace in a capture is treated as insignificant: " Foo"
-        # and "Foo" collapse to "Foo", and a capture that is empty / whitespace-only
-        # is dropped. This matches the realistic smali case where a leading space
-        # may end up inside a tolerant regex group, and prevents spurious
-        # TooManyMatchesError when the same readable name is captured twice with
-        # different ambient whitespace. See the README "Dynamic Class Names" section.
-        captures = {c.strip() for c in captures if c and c.strip()}
-        if not captures:
-            raise NoMatchesError(self.name, tuple(signatures))
-        # TODO: remove this single-capture restriction when the analyzer is
-        # generalized to emit a list of MatchedClass results in commit 6.
-        if len(captures) > 1:
-            raise TooManyMatchesError[str](self.name, tuple(signatures), captures)
-        return next(iter(captures))
+        matched: list[Result] = []
+        for smali_file in class_matches:
+            raw_class = smali_file.read_text()
+            captures: set[str] = set()
+            for signature in signatures:
+                if isinstance(signature, BaseRegexSignature):
+                    captures.update(signature.capture_class_name(raw_class))
+            # Surrounding whitespace in a capture is treated as insignificant: " Foo"
+            # and "Foo" collapse to "Foo", and a capture that is empty / whitespace-only
+            # is dropped. See the README "Dynamic Definitions" section.
+            captures = {c.strip() for c in captures if c and c.strip()}
+            for readable_name in captures:
+                matched.append(self._build_matched_class(smali_file, readable_name))
+        return matched
 
     @override
     def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
@@ -343,21 +335,77 @@ class ChildAnalyzer(Analyzer, ABC):
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
         raise NotImplementedError()
 
-    def _get_parent_match(self, results: ResultsMapType) -> MatchedClass:
+    @abstractmethod
+    def _analyze_for_parent(self, parent_class_result: MatchedClass, signatures: tuple[Signature, ...]) -> Result:
+        """Produce a single Result for one parent class match.
+
+        Raises a SigmatcherError if this child cannot match against this parent — the
+        outer template method `analyze` translates that into the all-or-nothing failure
+        decision (see decision #6 in the redesign spec).
+        """
+        raise NotImplementedError()
+
+    def _get_parent_matches(self, results: ResultsMapType) -> list[MatchedClass]:
         parent_class_results = results[self.parent.name]
         assert not isinstance(parent_class_results, Exception)
-        assert len(parent_class_results) == 1
-        parent_class_result = parent_class_results[0]
-        assert isinstance(parent_class_result, MatchedClass)
-        return parent_class_result
+        parents: list[MatchedClass] = []
+        for entry in parent_class_results:
+            assert isinstance(entry, MatchedClass)
+            parents.append(entry)
+        return parents
+
+    @override
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        parents = self._get_parent_matches(results)
+        if not parents:
+            # Parent dynamic def matched 0 entities → child runs 0 times. Decision #8.
+            return []
+        signatures = self._resolve_signatures_or_raise(results)
+        # All-or-nothing across the N parent matches (decision #6): if any single
+        # parent fails, the entire child result is one SigmatcherError, not a mixed
+        # list. This keeps the result typing clean for downstream consumers.
+        child_results: list[Result] = []
+        for parent in parents:
+            child_result = self._analyze_for_parent(parent, signatures)
+            self._update_parent_with_child_result(child_result, parent)
+            child_results.append(child_result)
+        return child_results
+
+    def _resolve_signatures_or_raise(self, results: ResultsMapType) -> tuple[Signature, ...]:
+        signatures = self.get_resolved_signatures(results)
+        if len(signatures) == 0:
+            raise NoSignaturesError(self.name)
+        return signatures
 
     @override
     def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
-        parent_class_result = self._get_parent_match(results)
+        parents_by_smali = {parent.new.to_java_representation(): parent for parent in self._get_parent_matches(results)}
         for cached_result in cached_results:
-            self._update_parent_with_child_result(cached_result, parent_class_result)
+            # Cached child results store the parent's obfuscated java repr so we can
+            # re-link them to the right parent after a multi-match parent.
+            parent = self._parent_for_cached(cached_result, parents_by_smali)
+            if parent is None:
+                # Parent set changed between runs (e.g. a previously-cached parent is no
+                # longer matched). Skip — the orchestrator will re-run the child rather
+                # than serving a stale cache hit.
+                continue
+            self._update_parent_with_child_result(cached_result, parent)
 
         return super().from_cache(cached_results, results)
+
+    def _parent_for_cached(
+        self, cached_result: Result, parents_by_smali: dict[str, MatchedClass]
+    ) -> MatchedClass | None:
+        # Cached children carry the parent's obfuscated java repr via `smali_class`
+        # (see MatchedField/MatchedMethod/MatchedExport). Use it as the parent_match_id
+        # so we re-link correctly after a multi-match parent.
+        smali_class = getattr(cached_result, "smali_class", None)
+        if smali_class is not None:
+            return parents_by_smali.get(smali_class.to_java_representation())  # pyright: ignore[reportAny]
+        # Fallback for single-parent children — match the only available parent.
+        if len(parents_by_smali) == 1:
+            return next(iter(parents_by_smali.values()))
+        return None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -365,13 +413,8 @@ class FieldAnalyzer(ChildAnalyzer):
     definition: FieldDefinition
 
     @override
-    def analyze(self, results: ResultsMapType) -> list[Result]:
-        parent_class_result = self._get_parent_match(results)
+    def _analyze_for_parent(self, parent_class_result: MatchedClass, signatures: tuple[Signature, ...]) -> Result:
         assert isinstance(parent_class_result.smali_file, Path)
-
-        signatures = self.get_resolved_signatures(results)
-        if len(signatures) == 0:
-            raise NoSignaturesError(self.name)
         if len(signatures) > 1:
             raise TooManySignaturesError(self.name, signatures)
         signature = signatures[0]
@@ -384,9 +427,7 @@ class FieldAnalyzer(ChildAnalyzer):
         new_field = Field.from_java_representation(raw_field_name)
         # TODO: should we get the types for the original field from the definition?
         original_field = Field(name=self.definition.name, type=new_field.type)
-        matched_field = MatchedField(original=original_field, new=new_field)
-        self._update_parent_with_child_result(matched_field, parent_class_result)
-        return [matched_field]
+        return MatchedField(original=original_field, new=new_field, smali_class=parent_class_result.new)
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -404,16 +445,11 @@ class MethodAnalyzer(ChildAnalyzer):
     definition: MethodDefinition
 
     @override
-    def analyze(self, results: ResultsMapType) -> list[Result]:
-        parent_class_result = self._get_parent_match(results)
+    def _analyze_for_parent(self, parent_class_result: MatchedClass, signatures: tuple[Signature, ...]) -> Result:
         assert isinstance(parent_class_result.smali_file, Path)
 
         raw_methods = parent_class_result.smali_file.read_text().split(".method")[1:]
         methods = {".method" + method for method in raw_methods}
-
-        signatures = self.get_resolved_signatures(results)
-        if len(signatures) == 0:
-            raise NoSignaturesError(self.name)
 
         def check_signature_callback(signature: Signature, matches: set[str]) -> list[str]:
             return signature.check_strings(matches)
@@ -430,9 +466,7 @@ class MethodAnalyzer(ChildAnalyzer):
         original_method = Method(
             name=self.definition.name, argument_types=new_method.argument_types, return_type=new_method.return_type
         )
-        matched_method = MatchedMethod(original=original_method, new=new_method)
-        self._update_parent_with_child_result(matched_method, parent_class_result)
-        return [matched_method]
+        return MatchedMethod(original=original_method, new=new_method, smali_class=parent_class_result.new)
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -450,13 +484,8 @@ class ExportAnalyzer(ChildAnalyzer):
     definition: ExportDefinition
 
     @override
-    def analyze(self, results: ResultsMapType) -> list[Result]:
-        parent_class_result = self._get_parent_match(results)
+    def _analyze_for_parent(self, parent_class_result: MatchedClass, signatures: tuple[Signature, ...]) -> Result:
         assert isinstance(parent_class_result.smali_file, Path)
-
-        signatures = self.get_resolved_signatures(results)
-        if len(signatures) == 0:
-            raise NoSignaturesError(self.name)
         if len(signatures) > 1:
             raise TooManySignaturesError(self.name, signatures)
         signature = signatures[0]
@@ -466,9 +495,7 @@ class ExportAnalyzer(ChildAnalyzer):
         self.check_match_count(captured_names, signatures)
         export_value = next(iter(captured_names))
 
-        result = MatchedExport.from_value(self.definition.name, export_value)
-        self._update_parent_with_child_result(result, parent_class_result)
-        return [result]
+        return MatchedExport.from_value(self.definition.name, export_value, smali_class=parent_class_result.new)
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -509,18 +536,6 @@ class TopLevelDynamicAnalyzer(Analyzer, ABC):
             return self.definition.name
         return self._capture_axis_name(match)
 
-    def _enforce_single_match_for_now(self, matches: list[Result], signatures: tuple[Signature, ...]) -> None:
-        # TODO: lift this restriction in commit 6 when 0+ dynamic matches become legal.
-        if len(matches) == 0:
-            raise NoMatchesError(self.name, signatures)
-        if len(matches) > 1:
-            seen = self._distinct_capture_names(matches)
-            raise TooManyMatchesError[str](self.name, signatures, seen)
-
-    @abstractmethod
-    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
-        raise NotImplementedError()
-
 
 @dataclasses.dataclass(frozen=True)
 class TopLevelDynamicMethodAnalyzer(TopLevelDynamicAnalyzer):
@@ -537,9 +552,7 @@ class TopLevelDynamicMethodAnalyzer(TopLevelDynamicAnalyzer):
     @override
     def analyze(self, results: ResultsMapType) -> list[Result]:
         signature = self._resolve_single_signature(results)
-        matches: list[Result] = list(self._scan_corpus(signature))
-        self._enforce_single_match_for_now(matches, (signature,))
-        return matches
+        return list(self._scan_corpus(signature))
 
     def _scan_corpus(self, signature: Signature) -> Iterable[MatchedMethod]:
         if not isinstance(signature, BaseRegexSignature):
@@ -567,13 +580,9 @@ class TopLevelDynamicMethodAnalyzer(TopLevelDynamicAnalyzer):
             )
             yield MatchedMethod(original=original_method, new=new_method, smali_class=smali_class)
             # One match per method block — additional captures inside the same method
-            # would be duplicate-emitting the same MatchedMethod and confuse downstream
-            # collision detection.
+            # body would re-emit the same MatchedMethod under different readable names,
+            # which confuses downstream collision detection.
             return
-
-    @override
-    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
-        return {m.original.name for m in matches if isinstance(m, MatchedMethod)}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -586,9 +595,7 @@ class TopLevelDynamicFieldAnalyzer(TopLevelDynamicAnalyzer):
     @override
     def analyze(self, results: ResultsMapType) -> list[Result]:
         signature = self._resolve_single_signature(results)
-        matches: list[Result] = list(self._scan_corpus(signature))
-        self._enforce_single_match_for_now(matches, (signature,))
-        return matches
+        return list(self._scan_corpus(signature))
 
     def _scan_corpus(self, signature: Signature) -> Iterable[MatchedField]:
         if not isinstance(signature, BaseRegexSignature):
@@ -609,10 +616,6 @@ class TopLevelDynamicFieldAnalyzer(TopLevelDynamicAnalyzer):
         original_field = Field(name=readable_name, type=new_field.type)
         return MatchedField(original=original_field, new=new_field, smali_class=smali_class)
 
-    @override
-    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
-        return {m.original.name for m in matches if isinstance(m, MatchedField)}
-
 
 @dataclasses.dataclass(frozen=True)
 class TopLevelDynamicExportAnalyzer(TopLevelDynamicAnalyzer):
@@ -624,9 +627,7 @@ class TopLevelDynamicExportAnalyzer(TopLevelDynamicAnalyzer):
     @override
     def analyze(self, results: ResultsMapType) -> list[Result]:
         signature = self._resolve_single_signature(results)
-        matches: list[Result] = list(self._scan_corpus(signature))
-        self._enforce_single_match_for_now(matches, (signature,))
-        return matches
+        return list(self._scan_corpus(signature))
 
     def _scan_corpus(self, signature: Signature) -> Iterable[MatchedExport]:
         if not isinstance(signature, BaseRegexSignature):
@@ -644,10 +645,6 @@ class TopLevelDynamicExportAnalyzer(TopLevelDynamicAnalyzer):
         if readable_name is None:
             return None
         return MatchedExport.from_value(readable_name, export_value, smali_class=smali_class)
-
-    @override
-    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
-        return {m.new.name for m in matches if isinstance(m, MatchedExport)}
 
 
 def _iter_method_blocks(smali_text: str) -> Iterable[str]:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -448,6 +448,11 @@ class FieldAnalyzer(ChildAnalyzer):
     @override
     def _analyze_for_parent(self, parent_class_result: MatchedClass, signatures: tuple[Signature, ...]) -> Result:
         assert isinstance(parent_class_result.smali_file, Path)
+        if not signatures:
+            # Defensive: ChildAnalyzer._resolve_signatures_or_raise already enforces
+            # the same check up the call stack. The narrowing here exists for basedpyright,
+            # which otherwise sees signatures[0] as a `tuple[()]` indexing error.
+            raise NoSignaturesError(self.name)
         if len(signatures) > 1:
             raise TooManySignaturesError(self.name, signatures)
         signature = signatures[0]
@@ -519,6 +524,9 @@ class ExportAnalyzer(ChildAnalyzer):
     @override
     def _analyze_for_parent(self, parent_class_result: MatchedClass, signatures: tuple[Signature, ...]) -> Result:
         assert isinstance(parent_class_result.smali_file, Path)
+        if not signatures:
+            # Defensive: see FieldAnalyzer._analyze_for_parent for the same narrowing rationale.
+            raise NoSignaturesError(self.name)
         if len(signatures) > 1:
             raise TooManySignaturesError(self.name, signatures)
         signature = signatures[0]

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -29,6 +29,7 @@ from sigmatcher.definitions import (
     TopLevelMethodDefinition,
 )
 from sigmatcher.errors import (
+    ChildFailedForParentError,
     FailedDependencyError,
     InvalidMacroModifierError,
     MissingDependenciesError,
@@ -363,10 +364,22 @@ class ChildAnalyzer(Analyzer, ABC):
         signatures = self._resolve_signatures_or_raise(results)
         # All-or-nothing across the N parent matches (decision #6): if any single
         # parent fails, the entire child result is one SigmatcherError, not a mixed
-        # list. This keeps the result typing clean for downstream consumers.
-        child_results: list[Result] = []
+        # list. Per-parent successes are accumulated into a local list and only
+        # written to the parents (via _update_parent_with_child_result) once we know
+        # every parent succeeded — otherwise downstream consumers would see a
+        # partial state where some parents have the child attached and others
+        # don't, with the child as a whole reported as failed.
+        per_parent_results: list[tuple[MatchedClass, Result]] = []
         for parent in parents:
-            child_result = self._analyze_for_parent(parent, signatures)
+            try:
+                child_result = self._analyze_for_parent(parent, signatures)
+            except SigmatcherError as underlying:
+                raise ChildFailedForParentError(
+                    self.name, parent.new.to_java_representation(), underlying
+                ) from underlying
+            per_parent_results.append((parent, child_result))
+        child_results: list[Result] = []
+        for parent, child_result in per_parent_results:
             self._update_parent_with_child_result(child_result, parent)
             child_results.append(child_result)
         return child_results

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -165,7 +165,10 @@ class Analyzer(ABC):
 
     def get_cache_key(self, results: ResultsMapType) -> str:
         analyzer_content_hash = hashlib.sha256(self._get_cache_content_to_hash(results))
-        return f"v4_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
+        # v5: cache value shape changed from a single Result to list[Result] to support
+        # dynamic definitions that emit 0+ matches. Previous-version caches are silently
+        # ignored (they fail validation and miss).
+        return f"v5_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
 
     @property
     def name(self) -> str:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from sigmatcher.cache import Cache, ResultsCacheType
 from sigmatcher.definitions import (
     SIGNATURES_TYPE_ADAPTER,
+    BaseRegexSignature,
     ClassDefinition,
     Definition,
     ExportDefinition,
@@ -151,7 +152,7 @@ class Analyzer(ABC):
 
     def get_cache_key(self, results: dict[str, Result | SigmatcherError]) -> str:
         analyzer_content_hash = hashlib.sha256(self._get_cache_content_to_hash(results))
-        return f"v3_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
+        return f"v4_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
 
     @property
     def name(self) -> str:
@@ -196,7 +197,22 @@ class ClassAnalyzer(Analyzer):
             class_definition_line = f.readline().rstrip("\n")
         _, _, raw_class_name = class_definition_line.rpartition(" ")
         new_class = Class.from_java_representation(raw_class_name)
-        original_class = Class(name=self.definition.name, package=self.definition.package or new_class.package)
+
+        readable_name = self.definition.name
+        if self.definition.dynamic_name:
+            raw_class = match.read_text()
+            captures: set[str] = set()
+            for signature in signatures:
+                if isinstance(signature, BaseRegexSignature):
+                    captures.update(signature.capture_class_name(raw_class))
+            captures = {c.strip() for c in captures if c and c.strip()}
+            if not captures:
+                raise NoMatchesError(self.name, tuple(signatures))
+            if len(captures) > 1:
+                raise TooManyMatchesError[str](self.name, tuple(signatures), captures)
+            readable_name = next(iter(captures))
+
+        original_class = Class(name=readable_name, package=self.definition.package or new_class.package)
         return MatchedClass(
             original=original_class, new=new_class, smali_file=match, matched_methods=[], matched_fields=[], exports=[]
         )
@@ -206,7 +222,8 @@ class ClassAnalyzer(Analyzer):
         assert isinstance(cached_result, MatchedClass)
         assert cached_result.smali_file is not None, "Cached MatchedClass must have a smali_file"
 
-        original_class = Class(name=self.definition.name, package=self.definition.package or cached_result.new.package)
+        readable_name = cached_result.original.name if self.definition.dynamic_name else self.definition.name
+        original_class = Class(name=readable_name, package=self.definition.package or cached_result.new.package)
 
         return MatchedClass(
             original=original_class,

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -218,6 +218,12 @@ class ClassAnalyzer(Analyzer):
             for signature in signatures:
                 if isinstance(signature, BaseRegexSignature):
                     captures.update(signature.capture_class_name(raw_class))
+            # Surrounding whitespace in a capture is treated as insignificant: " Foo"
+            # and "Foo" collapse to "Foo", and a capture that is empty / whitespace-only
+            # is dropped. This matches the realistic smali case where a leading space
+            # may end up inside a tolerant regex group, and prevents spurious
+            # TooManyMatchesError when the same readable name is captured twice with
+            # different ambient whitespace. See the README "Dynamic Class Names" section.
             captures = {c.strip() for c in captures if c and c.strip()}
             if not captures:
                 raise NoMatchesError(self.name, tuple(signatures))

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -180,10 +180,11 @@ class Analyzer(ABC):
 
     def get_cache_key(self, results: ResultsMapType) -> str:
         analyzer_content_hash = hashlib.sha256(self._get_cache_content_to_hash(results))
-        # v5: cache value shape changed from a single Result to list[Result] to support
-        # dynamic definitions that emit 0+ matches. Previous-version caches are silently
-        # ignored (they fail validation and miss).
-        return f"v5_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
+        # v6: nested child results now carry `parent_original_name` so the cache-replay
+        # path can disambiguate parents that share one smali file but carry different
+        # captured readable names. Previous-version caches are silently ignored (they
+        # fail validation and miss).
+        return f"v6_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
 
     @property
     def name(self) -> str:
@@ -407,14 +408,14 @@ class ChildAnalyzer(Analyzer, ABC):
             for parent in self._get_parent_matches(results)
         }
         for cached_result in cached_results:
-            # Cached child results store the parent's obfuscated java repr so we can
-            # re-link them to the right parent after a multi-match parent.
+            # Cached child results store the parent's obfuscated java repr (via
+            # `smali_class`) AND the parent's readable `original.name` (via
+            # `parent_original_name`) so we can re-link unambiguously even when
+            # multiple parents share one smali file.
             parent = self._parent_for_cached(cached_result, parents_by_smali)
             if parent is None:
                 # Parent set changed between runs (e.g. a previously-cached parent is no
-                # longer matched, or multiple parents now share a smali file in a way
-                # that's ambiguous on cache replay). Skip — the orchestrator will re-run
-                # the child rather than serving a stale cache hit.
+                # longer matched). Skip — the cached child is stale.
                 continue
             self._update_parent_with_child_result(cached_result, parent)
 
@@ -423,13 +424,19 @@ class ChildAnalyzer(Analyzer, ABC):
     def _parent_for_cached(
         self, cached_result: Result, parents_by_smali: dict[tuple[str, str], MatchedClass]
     ) -> MatchedClass | None:
-        # Cached children carry the parent's obfuscated java repr via `smali_class`
-        # (see MatchedField/MatchedMethod/MatchedExport). The cached child does not
-        # carry the parent's readable name, so when multiple parents share a smali
-        # file we can't disambiguate from the cache alone — return None to force a
-        # re-analysis, which is correct (no stale link) but not a cache hit.
+        # Cached children carry both the parent's obfuscated java repr via `smali_class`
+        # and the parent's readable name via `parent_original_name` (see MatchedField/
+        # MatchedMethod/MatchedExport). The composite key lets us re-link even when
+        # one smali file produces multiple parents with different captured names.
         smali_class = getattr(cached_result, "smali_class", None)
+        parent_original_name = getattr(cached_result, "parent_original_name", None)
+        if smali_class is not None and parent_original_name is not None:
+            smali_java = smali_class.to_java_representation()  # pyright: ignore[reportAny]
+            return parents_by_smali.get((smali_java, parent_original_name))
         if smali_class is not None:
+            # Legacy cached entries (pre-v6) without parent_original_name. Fall back to
+            # the old single-key lookup, which is correct as long as no two parents share
+            # a smali file.
             smali_java = smali_class.to_java_representation()  # pyright: ignore[reportAny]
             same_smali = [parent for key, parent in parents_by_smali.items() if key[0] == smali_java]
             if len(same_smali) == 1:
@@ -467,7 +474,12 @@ class FieldAnalyzer(ChildAnalyzer):
         new_field = Field.from_java_representation(raw_field_name)
         # TODO: should we get the types for the original field from the definition?
         original_field = Field(name=self.definition.name, type=new_field.type)
-        return MatchedField(original=original_field, new=new_field, smali_class=parent_class_result.new)
+        return MatchedField(
+            original=original_field,
+            new=new_field,
+            smali_class=parent_class_result.new,
+            parent_original_name=parent_class_result.original.name,
+        )
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -506,7 +518,12 @@ class MethodAnalyzer(ChildAnalyzer):
         original_method = Method(
             name=self.definition.name, argument_types=new_method.argument_types, return_type=new_method.return_type
         )
-        return MatchedMethod(original=original_method, new=new_method, smali_class=parent_class_result.new)
+        return MatchedMethod(
+            original=original_method,
+            new=new_method,
+            smali_class=parent_class_result.new,
+            parent_original_name=parent_class_result.original.name,
+        )
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -538,7 +555,12 @@ class ExportAnalyzer(ChildAnalyzer):
         self.check_match_count(captured_names, signatures)
         export_value = next(iter(captured_names))
 
-        return MatchedExport.from_value(self.definition.name, export_value, smali_class=parent_class_result.new)
+        return MatchedExport.from_value(
+            self.definition.name,
+            export_value,
+            smali_class=parent_class_result.new,
+            parent_original_name=parent_class_result.original.name,
+        )
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -23,6 +23,7 @@ from sigmatcher.definitions import (
 from sigmatcher.errors import (
     FailedDependencyError,
     InvalidMacroModifierError,
+    MissingClassNameGroupError,
     MissingDependenciesError,
     NoMatchesError,
     NoSignaturesError,
@@ -200,6 +201,18 @@ class ClassAnalyzer(Analyzer):
 
         readable_name = self.definition.name
         if self.definition.dynamic_name:
+            # The model-level validator only sees the full signature tuple. The runtime
+            # subset is version-filtered, so a definition with a non-capturing signature
+            # for old versions and a capturing one for new versions can pass validation
+            # yet have no class_name group applicable to the current run. Surface this
+            # as a dedicated error instead of the misleading NoMatchesError that the
+            # capture loop would otherwise raise.
+            if not any(
+                isinstance(signature, BaseRegexSignature) and signature.has_class_name_group()
+                for signature in signatures
+            ):
+                raise MissingClassNameGroupError(self.name, self.app_version)
+
             raw_class = match.read_text()
             captures: set[str] = set()
             for signature in signatures:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -27,6 +27,7 @@ from sigmatcher.definitions import (
     TopLevelExportDefinition,
     TopLevelFieldDefinition,
     TopLevelMethodDefinition,
+    validate_definitions,
 )
 from sigmatcher.errors import (
     ChildFailedForParentError,
@@ -39,6 +40,7 @@ from sigmatcher.errors import (
     SigmatcherError,
     TooManyMatchesError,
     TooManySignaturesError,
+    UnexpectedMultiResultMacroError,
 )
 from sigmatcher.results import (
     Class,
@@ -119,8 +121,12 @@ def resolve_signatures(
             assert not isinstance(result_entries, Exception)
             # Macros are forbidden against dynamic-name definitions (see the
             # validation pass that runs after merge_definitions_groups), so the
-            # referenced result is always a singleton list.
-            assert len(result_entries) == 1
+            # referenced result must be a singleton list. Anything else means the
+            # upstream validator was skipped — raise a real SigmatcherError so the
+            # orchestrator can record the failure instead of crashing with
+            # AssertionError on a code path users can reach via the programmatic API.
+            if len(result_entries) != 1:
+                raise UnexpectedMultiResultMacroError(analyzer_name, macro_statement.subject, len(result_entries))
             result = result_entries[0]
             resolved_macro = resolve_macro(result, macro_statement, analyzer_name)
             resolved_signature = resolved_signature.resolve_macro(macro_statement, resolved_macro)
@@ -775,6 +781,11 @@ def analyze(
     app_version: str | None,
     progress_observer: ProgressObserver | None = None,
 ) -> ResultsMapType:
+    # Cross-definition validation (e.g. forbid macros pointing at dynamic defs) lives
+    # in `validate_definitions` and is also called by the CLI's `_read_definitions`.
+    # Call it here too so programmatic callers using `sigmatcher.analysis.analyze`
+    # directly cannot bypass the rule and crash later on AssertionError.
+    validate_definitions(definitions)
     results: ResultsMapType = {}
     name_to_analyzer = create_analyzers(definitions, cache.get_apktool_cache_dir(), app_version)
     sorted_analyzers = list(sort_analyzers(name_to_analyzer, results))

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -48,6 +48,13 @@ else:
     from typing_extensions import override
 
 
+# Each analyzer produces zero or more results. Static analyzers always produce
+# exactly one entry; dynamic analyzers may produce 0+ entries. The dict value
+# is either the list of matches or the SigmatcherError raised while computing
+# it.
+ResultsMapType = dict[str, list[Result] | SigmatcherError]
+
+
 class ProgressObserver(ABC):
     @abstractmethod
     def on_start(self, total_analyzers: int) -> None:
@@ -93,14 +100,19 @@ def resolve_macro(result: Result, macro_statement: MacroStatement, analyzer_name
 
 
 def resolve_signatures(
-    signatures: tuple[Signature, ...], results: dict[str, Result | SigmatcherError], analyzer_name: str
+    signatures: tuple[Signature, ...], results: ResultsMapType, analyzer_name: str
 ) -> tuple[Signature, ...]:
     resolved_signatures: list[Signature] = []
     for signature in signatures:
         resolved_signature = signature
         for macro_statement in signature.get_macro_definitions():
-            result = results[macro_statement.subject]
-            assert not isinstance(result, Exception)
+            result_entries = results[macro_statement.subject]
+            assert not isinstance(result_entries, Exception)
+            # Macros are forbidden against dynamic-name definitions (see the
+            # validation pass that runs after merge_definitions_groups), so the
+            # referenced result is always a singleton list.
+            assert len(result_entries) == 1
+            result = result_entries[0]
             resolved_macro = resolve_macro(result, macro_statement, analyzer_name)
             resolved_signature = resolved_signature.resolve_macro(macro_statement, resolved_macro)
         resolved_signatures.append(resolved_signature)
@@ -114,7 +126,7 @@ class Analyzer(ABC):
     app_version: str | None
 
     @abstractmethod
-    def analyze(self, results: dict[str, Result | SigmatcherError]) -> Result:
+    def analyze(self, results: ResultsMapType) -> list[Result]:
         pass
 
     def check_match_count(
@@ -132,7 +144,7 @@ class Analyzer(ABC):
     def dependencies(self) -> set[str]:
         return self._get_dependencies()
 
-    def check_dependencies(self, results: dict[str, Result | SigmatcherError]) -> None:
+    def check_dependencies(self, results: ResultsMapType) -> None:
         failed_dependencies: list[str] = []
         for dependency_name in self.dependencies:
             child_result = results[dependency_name]
@@ -142,16 +154,16 @@ class Analyzer(ABC):
         if failed_dependencies:
             raise FailedDependencyError(self.name, failed_dependencies)
 
-    def get_resolved_signatures(self, results: dict[str, Result | SigmatcherError]) -> tuple[Signature, ...]:
+    def get_resolved_signatures(self, results: ResultsMapType) -> tuple[Signature, ...]:
         return resolve_signatures(self.get_signatures_for_version(), results, self.name)
 
     def get_signatures_for_version(self) -> tuple[Signature, ...]:
         return self.definition.get_signatures_for_version(self.app_version)
 
-    def _get_cache_content_to_hash(self, results: dict[str, Result | SigmatcherError]) -> bytes:
+    def _get_cache_content_to_hash(self, results: ResultsMapType) -> bytes:
         return SIGNATURES_TYPE_ADAPTER.dump_json(self.get_resolved_signatures(results))
 
-    def get_cache_key(self, results: dict[str, Result | SigmatcherError]) -> str:
+    def get_cache_key(self, results: ResultsMapType) -> str:
         analyzer_content_hash = hashlib.sha256(self._get_cache_content_to_hash(results))
         return f"v4_{self.name}_{self.app_version}_{analyzer_content_hash.hexdigest()}"
 
@@ -163,8 +175,8 @@ class Analyzer(ABC):
     def __repr__(self) -> str:
         return self.name
 
-    def from_cache(self, cached_result: Result, results: dict[str, Result | SigmatcherError]) -> Result:
-        return cached_result
+    def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
+        return list(cached_results)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -173,7 +185,7 @@ class ClassAnalyzer(Analyzer):
     search_root: Path
 
     @override
-    def analyze(self, results: dict[str, Result | SigmatcherError]) -> MatchedClass:
+    def analyze(self, results: ResultsMapType) -> list[Result]:
         signatures = list(self.get_resolved_signatures(results))
         if len(signatures) == 0:
             raise NoSignaturesError(self.name)
@@ -204,9 +216,16 @@ class ClassAnalyzer(Analyzer):
             readable_name = self._capture_dynamic_name(match, signatures)
 
         original_class = Class(name=readable_name, package=self.definition.package or new_class.package)
-        return MatchedClass(
-            original=original_class, new=new_class, smali_file=match, matched_methods=[], matched_fields=[], exports=[]
-        )
+        return [
+            MatchedClass(
+                original=original_class,
+                new=new_class,
+                smali_file=match,
+                matched_methods=[],
+                matched_fields=[],
+                exports=[],
+            )
+        ]
 
     def _capture_dynamic_name(self, match: Path, signatures: Sequence[Signature]) -> str:
         # The model-level validator only sees the full signature tuple. The runtime
@@ -239,21 +258,26 @@ class ClassAnalyzer(Analyzer):
         return next(iter(captures))
 
     @override
-    def from_cache(self, cached_result: Result, results: dict[str, Result | SigmatcherError]) -> MatchedClass:
-        assert isinstance(cached_result, MatchedClass)
-        assert cached_result.smali_file is not None, "Cached MatchedClass must have a smali_file"
+    def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
+        rebuilt: list[Result] = []
+        for cached_result in cached_results:
+            assert isinstance(cached_result, MatchedClass)
+            assert cached_result.smali_file is not None, "Cached MatchedClass must have a smali_file"
 
-        readable_name = cached_result.original.name if self.definition.dynamic_name else self.definition.name
-        original_class = Class(name=readable_name, package=self.definition.package or cached_result.new.package)
+            readable_name = cached_result.original.name if self.definition.dynamic_name else self.definition.name
+            original_class = Class(name=readable_name, package=self.definition.package or cached_result.new.package)
 
-        return MatchedClass(
-            original=original_class,
-            new=cached_result.new,
-            matched_methods=[],
-            matched_fields=[],
-            exports=[],
-            smali_file=cached_result.smali_file,
-        )
+            rebuilt.append(
+                MatchedClass(
+                    original=original_class,
+                    new=cached_result.new,
+                    matched_methods=[],
+                    matched_fields=[],
+                    exports=[],
+                    smali_file=cached_result.smali_file,
+                )
+            )
+        return rebuilt
 
 
 @dataclasses.dataclass(frozen=True)
@@ -265,7 +289,7 @@ class ChildAnalyzer(Analyzer, ABC):
         return super()._get_dependencies() | {self.parent.name}
 
     @override
-    def _get_cache_content_to_hash(self, results: dict[str, Result | SigmatcherError]) -> bytes:
+    def _get_cache_content_to_hash(self, results: ResultsMapType) -> bytes:
         parent_cache_key = self.parent.get_cache_key(results).encode()
         return super()._get_cache_content_to_hash(results) + parent_cache_key
 
@@ -273,13 +297,21 @@ class ChildAnalyzer(Analyzer, ABC):
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
         raise NotImplementedError()
 
-    @override
-    def from_cache(self, cached_result: Result, results: dict[str, Result | SigmatcherError]) -> Result:
-        parent_class_result = results[self.parent.name]
+    def _get_parent_match(self, results: ResultsMapType) -> MatchedClass:
+        parent_class_results = results[self.parent.name]
+        assert not isinstance(parent_class_results, Exception)
+        assert len(parent_class_results) == 1
+        parent_class_result = parent_class_results[0]
         assert isinstance(parent_class_result, MatchedClass)
-        self._update_parent_with_child_result(cached_result, parent_class_result)
+        return parent_class_result
 
-        return super().from_cache(cached_result, results)
+    @override
+    def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
+        parent_class_result = self._get_parent_match(results)
+        for cached_result in cached_results:
+            self._update_parent_with_child_result(cached_result, parent_class_result)
+
+        return super().from_cache(cached_results, results)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -287,9 +319,8 @@ class FieldAnalyzer(ChildAnalyzer):
     definition: FieldDefinition
 
     @override
-    def analyze(self, results: dict[str, Result | SigmatcherError]) -> MatchedField:
-        parent_class_result = results[self.parent.name]
-        assert isinstance(parent_class_result, MatchedClass)
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        parent_class_result = self._get_parent_match(results)
         assert isinstance(parent_class_result.smali_file, Path)
 
         signatures = self.get_resolved_signatures(results)
@@ -309,7 +340,7 @@ class FieldAnalyzer(ChildAnalyzer):
         original_field = Field(name=self.definition.name, type=new_field.type)
         matched_field = MatchedField(original=original_field, new=new_field)
         self._update_parent_with_child_result(matched_field, parent_class_result)
-        return matched_field
+        return [matched_field]
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -327,9 +358,8 @@ class MethodAnalyzer(ChildAnalyzer):
     definition: MethodDefinition
 
     @override
-    def analyze(self, results: dict[str, Result | SigmatcherError]) -> MatchedMethod:
-        parent_class_result = results[self.parent.name]
-        assert isinstance(parent_class_result, MatchedClass)
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        parent_class_result = self._get_parent_match(results)
         assert isinstance(parent_class_result.smali_file, Path)
 
         raw_methods = parent_class_result.smali_file.read_text().split(".method")[1:]
@@ -356,7 +386,7 @@ class MethodAnalyzer(ChildAnalyzer):
         )
         matched_method = MatchedMethod(original=original_method, new=new_method)
         self._update_parent_with_child_result(matched_method, parent_class_result)
-        return matched_method
+        return [matched_method]
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -374,9 +404,8 @@ class ExportAnalyzer(ChildAnalyzer):
     definition: ExportDefinition
 
     @override
-    def analyze(self, results: dict[str, Result | SigmatcherError]) -> MatchedExport:
-        parent_class_result = results[self.parent.name]
-        assert isinstance(parent_class_result, MatchedClass)
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        parent_class_result = self._get_parent_match(results)
         assert isinstance(parent_class_result.smali_file, Path)
 
         signatures = self.get_resolved_signatures(results)
@@ -393,7 +422,7 @@ class ExportAnalyzer(ChildAnalyzer):
 
         result = MatchedExport.from_value(self.definition.name, export_value)
         self._update_parent_with_child_result(result, parent_class_result)
-        return result
+        return [result]
 
     @override
     def _update_parent_with_child_result(self, new_result: Result, parent_class_result: MatchedClass) -> None:
@@ -439,9 +468,7 @@ def create_analyzers(
     return name_to_analyzer
 
 
-def sort_analyzers(
-    name_to_analyzer: dict[str, Analyzer], results: dict[str, Result | SigmatcherError]
-) -> Iterable[str]:
+def sort_analyzers(name_to_analyzer: dict[str, Analyzer], results: ResultsMapType) -> Iterable[str]:
     analyzers_set = set(name_to_analyzer.keys())
 
     sorter: graphlib.TopologicalSorter[str] = graphlib.TopologicalSorter()
@@ -461,8 +488,8 @@ def analyze(
     cache: Cache,
     app_version: str | None,
     progress_observer: ProgressObserver | None = None,
-) -> dict[str, Result | SigmatcherError]:
-    results: dict[str, Result | SigmatcherError] = {}
+) -> ResultsMapType:
+    results: ResultsMapType = {}
     name_to_analyzer = create_analyzers(definitions, cache.get_apktool_cache_dir(), app_version)
     sorted_analyzers = list(sort_analyzers(name_to_analyzer, results))
 
@@ -485,12 +512,12 @@ def analyze(
             cache_key = analyzer.get_cache_key(results)
             cached_result = previous_results_cache.get(cache_key)
             if cached_result is None:
-                result = analyzer.analyze(results)
+                analyzer_results = analyzer.analyze(results)
             else:
-                result = analyzer.from_cache(cached_result, results)
+                analyzer_results = analyzer.from_cache(cached_result, results)
 
-            results[analyzer_name] = result
-            new_results_cache[cache_key] = result
+            results[analyzer_name] = analyzer_results
+            new_results_cache[cache_key] = analyzer_results
 
             if analyzer.definition.exclude:
                 excluded_results.append(analyzer_name)

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -180,12 +180,17 @@ class Analyzer(ABC):
 
 
 @dataclasses.dataclass(frozen=True)
-class ClassAnalyzer(Analyzer):
+class ClassAnalyzer(Analyzer, ABC):
+    """Common base for class-level analyzers (static and dynamic).
+
+    Subclasses share the file-filtering pipeline but differ in how the readable
+    `original.name` is computed and in how many matches they may emit.
+    """
+
     definition: ClassDefinition
     search_root: Path
 
-    @override
-    def analyze(self, results: ResultsMapType) -> list[Result]:
+    def _find_class_matches(self, results: ResultsMapType) -> tuple[list[Signature], set[Path]]:
         signatures = list(self.get_resolved_signatures(results))
         if len(signatures) == 0:
             raise NoSignaturesError(self.name)
@@ -203,29 +208,71 @@ class ClassAnalyzer(Analyzer):
 
         initial_matches = get_smali_files(self.search_root)
         class_matches = filter_signature_matches(signatures, initial_matches, check_signature_callback)
+        return signatures, class_matches
 
-        self.check_match_count(class_matches, tuple(signatures))
-        match = next(iter(class_matches))
+    @staticmethod
+    def _read_new_class(match: Path) -> Class:
         with match.open() as f:
             class_definition_line = f.readline().rstrip("\n")
         _, _, raw_class_name = class_definition_line.rpartition(" ")
-        new_class = Class.from_java_representation(raw_class_name)
+        return Class.from_java_representation(raw_class_name)
 
-        readable_name = self.definition.name
-        if self.definition.dynamic_name:
-            readable_name = self._capture_dynamic_name(match, signatures)
-
+    def _build_matched_class(self, match: Path, readable_name: str) -> MatchedClass:
+        new_class = self._read_new_class(match)
         original_class = Class(name=readable_name, package=self.definition.package or new_class.package)
-        return [
-            MatchedClass(
-                original=original_class,
-                new=new_class,
-                smali_file=match,
-                matched_methods=[],
-                matched_fields=[],
-                exports=[],
-            )
-        ]
+        return MatchedClass(
+            original=original_class,
+            new=new_class,
+            smali_file=match,
+            matched_methods=[],
+            matched_fields=[],
+            exports=[],
+        )
+
+    def _rebuild_cached_class(self, cached: MatchedClass, readable_name: str) -> MatchedClass:
+        assert cached.smali_file is not None, "Cached MatchedClass must have a smali_file"
+        original_class = Class(name=readable_name, package=self.definition.package or cached.new.package)
+        return MatchedClass(
+            original=original_class,
+            new=cached.new,
+            matched_methods=[],
+            matched_fields=[],
+            exports=[],
+            smali_file=cached.smali_file,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class StaticClassAnalyzer(ClassAnalyzer):
+    """A class analyzer whose `original.name` is the YAML `name` itself."""
+
+    @override
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        signatures, class_matches = self._find_class_matches(results)
+        self.check_match_count(class_matches, tuple(signatures))
+        match = next(iter(class_matches))
+        return [self._build_matched_class(match, self.definition.name)]
+
+    @override
+    def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
+        rebuilt: list[Result] = []
+        for cached_result in cached_results:
+            assert isinstance(cached_result, MatchedClass)
+            rebuilt.append(self._rebuild_cached_class(cached_result, self.definition.name))
+        return rebuilt
+
+
+@dataclasses.dataclass(frozen=True)
+class DynamicClassAnalyzer(ClassAnalyzer):
+    """A class analyzer whose `original.name` is captured from `(?P<class_name>...)`."""
+
+    @override
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        signatures, class_matches = self._find_class_matches(results)
+        self.check_match_count(class_matches, tuple(signatures))
+        match = next(iter(class_matches))
+        readable_name = self._capture_dynamic_name(match, signatures)
+        return [self._build_matched_class(match, readable_name)]
 
     def _capture_dynamic_name(self, match: Path, signatures: Sequence[Signature]) -> str:
         # The model-level validator only sees the full signature tuple. The runtime
@@ -253,6 +300,8 @@ class ClassAnalyzer(Analyzer):
         captures = {c.strip() for c in captures if c and c.strip()}
         if not captures:
             raise NoMatchesError(self.name, tuple(signatures))
+        # TODO: remove this single-capture restriction when the analyzer is
+        # generalized to emit a list of MatchedClass results in commit 6.
         if len(captures) > 1:
             raise TooManyMatchesError[str](self.name, tuple(signatures), captures)
         return next(iter(captures))
@@ -262,21 +311,7 @@ class ClassAnalyzer(Analyzer):
         rebuilt: list[Result] = []
         for cached_result in cached_results:
             assert isinstance(cached_result, MatchedClass)
-            assert cached_result.smali_file is not None, "Cached MatchedClass must have a smali_file"
-
-            readable_name = cached_result.original.name if self.definition.dynamic_name else self.definition.name
-            original_class = Class(name=readable_name, package=self.definition.package or cached_result.new.package)
-
-            rebuilt.append(
-                MatchedClass(
-                    original=original_class,
-                    new=cached_result.new,
-                    matched_methods=[],
-                    matched_fields=[],
-                    exports=[],
-                    smali_file=cached_result.smali_file,
-                )
-            )
+            rebuilt.append(self._rebuild_cached_class(cached_result, cached_result.original.name))
         return rebuilt
 
 
@@ -444,7 +479,11 @@ def create_analyzers(
         if not class_definition.is_in_version_range(app_version):
             continue
 
-        class_analyzer = ClassAnalyzer(class_definition, app_version, canonical_search_root)
+        class_analyzer: ClassAnalyzer
+        if class_definition.dynamic_name:
+            class_analyzer = DynamicClassAnalyzer(class_definition, app_version, canonical_search_root)
+        else:
+            class_analyzer = StaticClassAnalyzer(class_definition, app_version, canonical_search_root)
         name_to_analyzer[class_definition.name] = class_analyzer
 
         for method_definition in class_definition.methods:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -31,8 +31,8 @@ from sigmatcher.definitions import (
 from sigmatcher.errors import (
     FailedDependencyError,
     InvalidMacroModifierError,
-    MissingClassNameGroupError,
     MissingDependenciesError,
+    MissingDynamicCaptureGroupError,
     NoMatchesError,
     NoSignaturesError,
     SigmatcherError,
@@ -292,7 +292,7 @@ class DynamicClassAnalyzer(ClassAnalyzer):
             # old versions and a capturing one for new versions can pass validation yet
             # have no class_name group applicable to the current run. Surface that as a
             # dedicated error instead of silently returning an empty match list.
-            raise MissingClassNameGroupError(self.name, self.app_version)
+            raise MissingDynamicCaptureGroupError(self.name, self.app_version, "class", "class_name")
 
         matched: list[Result] = []
         for smali_file in class_matches:

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -392,29 +392,43 @@ class ChildAnalyzer(Analyzer, ABC):
 
     @override
     def from_cache(self, cached_results: list[Result], results: ResultsMapType) -> list[Result]:
-        parents_by_smali = {parent.new.to_java_representation(): parent for parent in self._get_parent_matches(results)}
+        # Key by (java repr, readable original name). A single dynamic parent def can
+        # legitimately emit N MatchedClass entries that share a smali file but carry
+        # different readable names (multiple captures from one class). Keying by java
+        # repr alone would have the second parent overwrite the first.
+        parents_by_smali: dict[tuple[str, str], MatchedClass] = {
+            (parent.new.to_java_representation(), parent.original.name): parent
+            for parent in self._get_parent_matches(results)
+        }
         for cached_result in cached_results:
             # Cached child results store the parent's obfuscated java repr so we can
             # re-link them to the right parent after a multi-match parent.
             parent = self._parent_for_cached(cached_result, parents_by_smali)
             if parent is None:
                 # Parent set changed between runs (e.g. a previously-cached parent is no
-                # longer matched). Skip — the orchestrator will re-run the child rather
-                # than serving a stale cache hit.
+                # longer matched, or multiple parents now share a smali file in a way
+                # that's ambiguous on cache replay). Skip — the orchestrator will re-run
+                # the child rather than serving a stale cache hit.
                 continue
             self._update_parent_with_child_result(cached_result, parent)
 
         return super().from_cache(cached_results, results)
 
     def _parent_for_cached(
-        self, cached_result: Result, parents_by_smali: dict[str, MatchedClass]
+        self, cached_result: Result, parents_by_smali: dict[tuple[str, str], MatchedClass]
     ) -> MatchedClass | None:
         # Cached children carry the parent's obfuscated java repr via `smali_class`
-        # (see MatchedField/MatchedMethod/MatchedExport). Use it as the parent_match_id
-        # so we re-link correctly after a multi-match parent.
+        # (see MatchedField/MatchedMethod/MatchedExport). The cached child does not
+        # carry the parent's readable name, so when multiple parents share a smali
+        # file we can't disambiguate from the cache alone — return None to force a
+        # re-analysis, which is correct (no stale link) but not a cache hit.
         smali_class = getattr(cached_result, "smali_class", None)
         if smali_class is not None:
-            return parents_by_smali.get(smali_class.to_java_representation())  # pyright: ignore[reportAny]
+            smali_java = smali_class.to_java_representation()  # pyright: ignore[reportAny]
+            same_smali = [parent for key, parent in parents_by_smali.items() if key[0] == smali_java]
+            if len(same_smali) == 1:
+                return same_smali[0]
+            return None
         # Fallback for single-parent children — match the only available parent.
         if len(parents_by_smali) == 1:
             return next(iter(parents_by_smali.values()))

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -6,6 +6,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from functools import cache, cached_property
 from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import re
 
 from sigmatcher.cache import Cache, ResultsCacheType
 from sigmatcher.definitions import (
@@ -19,6 +23,10 @@ from sigmatcher.definitions import (
     MethodDefinition,
     Signature,
     SignatureMatch,
+    TopLevelDefinition,
+    TopLevelExportDefinition,
+    TopLevelFieldDefinition,
+    TopLevelMethodDefinition,
 )
 from sigmatcher.errors import (
     FailedDependencyError,
@@ -214,14 +222,14 @@ class ClassAnalyzer(Analyzer, ABC):
         return signatures, class_matches
 
     @staticmethod
-    def _read_new_class(match: Path) -> Class:
+    def read_new_class(match: Path) -> Class:
         with match.open() as f:
             class_definition_line = f.readline().rstrip("\n")
         _, _, raw_class_name = class_definition_line.rpartition(" ")
         return Class.from_java_representation(raw_class_name)
 
     def _build_matched_class(self, match: Path, readable_name: str) -> MatchedClass:
-        new_class = self._read_new_class(match)
+        new_class = self.read_new_class(match)
         original_class = Class(name=readable_name, package=self.definition.package or new_class.package)
         return MatchedClass(
             original=original_class,
@@ -473,39 +481,242 @@ class ExportAnalyzer(ChildAnalyzer):
         return f"{self.parent.name}.exports.{self.definition.name}"
 
 
+@dataclasses.dataclass(frozen=True)
+class TopLevelDynamicAnalyzer(Analyzer, ABC):
+    """Common base for top-level corpus-scanning method/field/export analyzers."""
+
+    search_root: Path
+    capture_group_name: ClassVar[str] = ""
+
+    def _resolve_single_signature(self, results: ResultsMapType) -> Signature:
+        signatures = self.get_resolved_signatures(results)
+        if len(signatures) == 0:
+            raise NoSignaturesError(self.name)
+        if len(signatures) > 1:
+            raise TooManySignaturesError(self.name, signatures)
+        return signatures[0]
+
+    def _capture_axis_name(self, match: "re.Match[str]") -> str | None:
+        """Return the stripped axis-specific capture, or None if absent/empty."""
+        try:
+            captured = match.group(self.capture_group_name).strip()
+        except IndexError:
+            return None
+        return captured or None
+
+    def _readable_name_for(self, match: "re.Match[str]", *, dynamic_name: bool) -> str | None:
+        if not dynamic_name:
+            return self.definition.name
+        return self._capture_axis_name(match)
+
+    def _enforce_single_match_for_now(self, matches: list[Result], signatures: tuple[Signature, ...]) -> None:
+        # TODO: lift this restriction in commit 6 when 0+ dynamic matches become legal.
+        if len(matches) == 0:
+            raise NoMatchesError(self.name, signatures)
+        if len(matches) > 1:
+            seen = self._distinct_capture_names(matches)
+            raise TooManyMatchesError[str](self.name, signatures, seen)
+
+    @abstractmethod
+    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass(frozen=True)
+class TopLevelDynamicMethodAnalyzer(TopLevelDynamicAnalyzer):
+    """Scan the full smali corpus for methods matching a top-level method definition.
+
+    The readable method name comes from a `(?P<method_name>...)` capture group. Each
+    occurrence becomes its own MatchedMethod, tagged with the obfuscated parent class
+    so output formats can synthesize a holder class entry.
+    """
+
+    definition: TopLevelMethodDefinition
+    capture_group_name: ClassVar[str] = "method_name"
+
+    @override
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        signature = self._resolve_single_signature(results)
+        matches: list[Result] = list(self._scan_corpus(signature))
+        self._enforce_single_match_for_now(matches, (signature,))
+        return matches
+
+    def _scan_corpus(self, signature: Signature) -> Iterable[MatchedMethod]:
+        if not isinstance(signature, BaseRegexSignature):
+            return
+        for smali_file in get_smali_files(self.search_root):
+            smali_class = ClassAnalyzer.read_new_class(smali_file)
+            for method_block in _iter_method_blocks(smali_file.read_text()):
+                yield from self._yield_method_match(signature, method_block, smali_class)
+
+    def _yield_method_match(
+        self, signature: BaseRegexSignature, method_block: str, smali_class: Class
+    ) -> Iterable[MatchedMethod]:
+        regex = signature.signature
+        method_definition_line, _, _ = method_block.partition("\n")
+        _, _, raw_method_name = method_definition_line.rpartition(" ")
+        new_method = Method.from_java_representation(raw_method_name)
+        for match in regex.finditer(method_block):
+            readable_name = self._readable_name_for(match, dynamic_name=self.definition.dynamic_name)
+            if readable_name is None:
+                continue
+            original_method = Method(
+                name=readable_name,
+                argument_types=new_method.argument_types,
+                return_type=new_method.return_type,
+            )
+            yield MatchedMethod(original=original_method, new=new_method, smali_class=smali_class)
+            # One match per method block — additional captures inside the same method
+            # would be duplicate-emitting the same MatchedMethod and confuse downstream
+            # collision detection.
+            return
+
+    @override
+    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
+        return {m.original.name for m in matches if isinstance(m, MatchedMethod)}
+
+
+@dataclasses.dataclass(frozen=True)
+class TopLevelDynamicFieldAnalyzer(TopLevelDynamicAnalyzer):
+    """Scan the full smali corpus for fields matching a top-level field definition."""
+
+    definition: TopLevelFieldDefinition
+    capture_group_name: ClassVar[str] = "field_name"
+
+    @override
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        signature = self._resolve_single_signature(results)
+        matches: list[Result] = list(self._scan_corpus(signature))
+        self._enforce_single_match_for_now(matches, (signature,))
+        return matches
+
+    def _scan_corpus(self, signature: Signature) -> Iterable[MatchedField]:
+        if not isinstance(signature, BaseRegexSignature):
+            return
+        for smali_file in get_smali_files(self.search_root):
+            smali_class = ClassAnalyzer.read_new_class(smali_file)
+            for match in signature.signature.finditer(smali_file.read_text()):
+                yielded = self._build_field(match, smali_class)
+                if yielded is not None:
+                    yield yielded
+
+    def _build_field(self, match: "re.Match[str]", smali_class: Class) -> MatchedField | None:
+        raw_field = _captured_match_or_full(match)
+        new_field = Field.from_java_representation(raw_field)
+        readable_name = self._readable_name_for(match, dynamic_name=self.definition.dynamic_name)
+        if readable_name is None:
+            return None
+        original_field = Field(name=readable_name, type=new_field.type)
+        return MatchedField(original=original_field, new=new_field, smali_class=smali_class)
+
+    @override
+    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
+        return {m.original.name for m in matches if isinstance(m, MatchedField)}
+
+
+@dataclasses.dataclass(frozen=True)
+class TopLevelDynamicExportAnalyzer(TopLevelDynamicAnalyzer):
+    """Scan the full smali corpus for exports matching a top-level export definition."""
+
+    definition: TopLevelExportDefinition
+    capture_group_name: ClassVar[str] = "export_name"
+
+    @override
+    def analyze(self, results: ResultsMapType) -> list[Result]:
+        signature = self._resolve_single_signature(results)
+        matches: list[Result] = list(self._scan_corpus(signature))
+        self._enforce_single_match_for_now(matches, (signature,))
+        return matches
+
+    def _scan_corpus(self, signature: Signature) -> Iterable[MatchedExport]:
+        if not isinstance(signature, BaseRegexSignature):
+            return
+        for smali_file in get_smali_files(self.search_root):
+            smali_class = ClassAnalyzer.read_new_class(smali_file)
+            for match in signature.signature.finditer(smali_file.read_text()):
+                yielded = self._build_export(match, smali_class)
+                if yielded is not None:
+                    yield yielded
+
+    def _build_export(self, match: "re.Match[str]", smali_class: Class) -> MatchedExport | None:
+        export_value = _captured_match_or_full(match)
+        readable_name = self._readable_name_for(match, dynamic_name=self.definition.dynamic_name)
+        if readable_name is None:
+            return None
+        return MatchedExport.from_value(readable_name, export_value, smali_class=smali_class)
+
+    @override
+    def _distinct_capture_names(self, matches: list[Result]) -> set[str]:
+        return {m.new.name for m in matches if isinstance(m, MatchedExport)}
+
+
+def _iter_method_blocks(smali_text: str) -> Iterable[str]:
+    """Split a smali file's contents into individual method blocks."""
+    raw_methods = smali_text.split(".method")[1:]
+    for raw_method in raw_methods:
+        yield ".method" + raw_method
+
+
+def _captured_match_or_full(match: "re.Match[str]") -> str:
+    """Return `match.group("match")` if defined, else the full matched string."""
+    try:
+        return match.group("match")
+    except IndexError:
+        return match.group(0)
+
+
+def _create_class_analyzers(
+    class_definition: ClassDefinition, search_root: Path, app_version: str | None
+) -> Iterable[tuple[str, Analyzer]]:
+    class_analyzer: ClassAnalyzer
+    if class_definition.dynamic_name:
+        class_analyzer = DynamicClassAnalyzer(class_definition, app_version, search_root)
+    else:
+        class_analyzer = StaticClassAnalyzer(class_definition, app_version, search_root)
+    yield class_definition.name, class_analyzer
+
+    for method_definition in class_definition.methods:
+        if method_definition.is_in_version_range(app_version):
+            method_analyzer = MethodAnalyzer(method_definition, app_version, parent=class_analyzer)
+            yield method_analyzer.name, method_analyzer
+
+    for field_definition in class_definition.fields:
+        if field_definition.is_in_version_range(app_version):
+            field_analyzer = FieldAnalyzer(field_definition, app_version, parent=class_analyzer)
+            yield field_analyzer.name, field_analyzer
+
+    for export_definition in class_definition.exports:
+        if export_definition.is_in_version_range(app_version):
+            export_analyzer = ExportAnalyzer(export_definition, app_version, parent=class_analyzer)
+            yield export_analyzer.name, export_analyzer
+
+
+def _create_top_level_analyzer(
+    top_level_definition: TopLevelDefinition, search_root: Path, app_version: str | None
+) -> Analyzer:
+    if isinstance(top_level_definition, TopLevelMethodDefinition):
+        return TopLevelDynamicMethodAnalyzer(top_level_definition, app_version, search_root)
+    if isinstance(top_level_definition, TopLevelFieldDefinition):
+        return TopLevelDynamicFieldAnalyzer(top_level_definition, app_version, search_root)
+    assert isinstance(top_level_definition, TopLevelExportDefinition)
+    return TopLevelDynamicExportAnalyzer(top_level_definition, app_version, search_root)
+
+
 def create_analyzers(
-    definitions: Sequence[ClassDefinition], search_root: Path, app_version: str | None
+    definitions: Sequence[TopLevelDefinition], search_root: Path, app_version: str | None
 ) -> dict[str, Analyzer]:
     canonical_search_root = search_root.resolve()
     name_to_analyzer: dict[str, Analyzer] = {}
-    for class_definition in definitions:
-        if not class_definition.is_in_version_range(app_version):
+    for top_level_definition in definitions:
+        if not top_level_definition.is_in_version_range(app_version):
             continue
 
-        class_analyzer: ClassAnalyzer
-        if class_definition.dynamic_name:
-            class_analyzer = DynamicClassAnalyzer(class_definition, app_version, canonical_search_root)
+        if isinstance(top_level_definition, ClassDefinition):
+            for name, analyzer in _create_class_analyzers(top_level_definition, canonical_search_root, app_version):
+                name_to_analyzer[name] = analyzer
         else:
-            class_analyzer = StaticClassAnalyzer(class_definition, app_version, canonical_search_root)
-        name_to_analyzer[class_definition.name] = class_analyzer
-
-        for method_definition in class_definition.methods:
-            if not method_definition.is_in_version_range(app_version):
-                continue
-            method_analyzer = MethodAnalyzer(method_definition, app_version, parent=class_analyzer)
-            name_to_analyzer[method_analyzer.name] = method_analyzer
-
-        for field_definition in class_definition.fields:
-            if not field_definition.is_in_version_range(app_version):
-                continue
-            field_analyzer = FieldAnalyzer(field_definition, app_version, parent=class_analyzer)
-            name_to_analyzer[field_analyzer.name] = field_analyzer
-
-        for export_definition in class_definition.exports:
-            if not export_definition.is_in_version_range(app_version):
-                continue
-            export_analyzer = ExportAnalyzer(export_definition, app_version, parent=class_analyzer)
-            name_to_analyzer[export_analyzer.name] = export_analyzer
+            analyzer = _create_top_level_analyzer(top_level_definition, canonical_search_root, app_version)
+            name_to_analyzer[analyzer.name] = analyzer
 
     return name_to_analyzer
 
@@ -526,7 +737,7 @@ def sort_analyzers(name_to_analyzer: dict[str, Analyzer], results: ResultsMapTyp
 
 
 def analyze(
-    definitions: Sequence[ClassDefinition],
+    definitions: Sequence[TopLevelDefinition],
     cache: Cache,
     app_version: str | None,
     progress_observer: ProgressObserver | None = None,

--- a/src/sigmatcher/analysis.py
+++ b/src/sigmatcher/analysis.py
@@ -524,11 +524,20 @@ class TopLevelDynamicAnalyzer(Analyzer, ABC):
         return signatures[0]
 
     def _capture_axis_name(self, match: "re.Match[str]") -> str | None:
-        """Return the stripped axis-specific capture, or None if absent/empty."""
+        """Return the stripped axis-specific capture, or None if absent/empty.
+
+        A named group inside an alternation that didn't participate in the match
+        (e.g. `sentinel|(?P<method_name>FOO)` when the input matched `sentinel`)
+        returns None from `match.group(...)`. None and empty/whitespace-only
+        captures are treated as "no axis name" rather than raising.
+        """
         try:
-            captured = match.group(self.capture_group_name).strip()
+            captured_raw = match.group(self.capture_group_name)
         except IndexError:
             return None
+        if captured_raw is None:
+            return None
+        captured = captured_raw.strip()
         return captured or None
 
     def _readable_name_for(self, match: "re.Match[str]", *, dynamic_name: bool) -> str | None:

--- a/src/sigmatcher/cache.py
+++ b/src/sigmatcher/cache.py
@@ -26,7 +26,7 @@ class Cache:
     @classmethod
     def get_from_input(cls, base_cache_dir: Path, app_input: Path) -> Self:
         input_hash_hex = hash_input_path(app_input)
-        return cls(base_cache_dir / f"v3_{input_hash_hex}")
+        return cls(base_cache_dir / f"v4_{input_hash_hex}")
 
     def get_apktool_cache_dir(self) -> Path:
         return self.cache_dir / "apktool"

--- a/src/sigmatcher/cache.py
+++ b/src/sigmatcher/cache.py
@@ -26,7 +26,7 @@ class Cache:
     @classmethod
     def get_from_input(cls, base_cache_dir: Path, app_input: Path) -> Self:
         input_hash_hex = hash_input_path(app_input)
-        return cls(base_cache_dir / f"v4_{input_hash_hex}")
+        return cls(base_cache_dir / f"v3_{input_hash_hex}")
 
     def get_apktool_cache_dir(self) -> Path:
         return self.cache_dir / "apktool"

--- a/src/sigmatcher/cache.py
+++ b/src/sigmatcher/cache.py
@@ -16,7 +16,7 @@ else:
 
 DEFAULT_CACHE_DIR_PATH = platformdirs.user_cache_path("sigmatcher", "oriori1703", ensure_exists=True)
 
-ResultsCacheType: TypeAlias = dict[str, Result]
+ResultsCacheType: TypeAlias = dict[str, list[Result]]
 
 
 @dataclass

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -366,10 +366,6 @@ def analyze(  # noqa: PLR0913
         progress_console.quiet = True
 
     merged_definitions = _read_definitions(signatures)
-    # Top-level non-class definitions are validated and round-tripped, but not yet wired
-    # into the analyzer here — the dynamic Method/Field/Export top-level analyzers ship
-    # in a follow-up commit. Filter to class defs for now so analysis still runs.
-    class_definitions = tuple(d for d in merged_definitions if isinstance(d, ClassDefinition))
     cache = Cache.get_from_input(cache_dir, app_input)
     with progress_console.status("Unpacking APK..."):
         unpack_input(apktool, app_input, cache, suppress_output=not debug)
@@ -393,7 +389,7 @@ def analyze(  # noqa: PLR0913
         observer = RichProgressObserver(analysis_progress)
 
     with analysis_progress:
-        results = sigmatcher.analysis.analyze(class_definitions, cache, apk_version, observer)
+        results = sigmatcher.analysis.analyze(merged_definitions, cache, apk_version, observer)
 
     _output_results(results, output_file, output_format, tree_errors, debug)
     return results

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -284,12 +284,13 @@ def _output_failed_results_tree(failed_results: dict[str, SigmatcherError], debu
     stderr_console.print(tree)
 
 
-def _output_results(
+def _output_results(  # noqa: PLR0913
     results: ResultsMapType,
     output_file: Path | None,
     output_format: MappingFormat,
     output_errors_as_tree: bool,
     debug: bool,
+    child_analyzer_names: set[str] | None = None,
 ) -> None:
     successful_lists: dict[str, list[Result]] = {}
     failed_results: dict[str, SigmatcherError] = {}
@@ -300,7 +301,7 @@ def _output_results(
             continue
         successful_lists[analyzer_name] = result
 
-    flattened = flatten_analyzer_results(successful_lists)
+    flattened = flatten_analyzer_results(successful_lists, child_analyzer_names)
     _output_successful_results(flattened, output_file, output_format)
     if not failed_results:
         return
@@ -402,7 +403,15 @@ def analyze(  # noqa: PLR0913
     with analysis_progress:
         results = sigmatcher.analysis.analyze(merged_definitions, cache, apk_version, observer)
 
-    _output_results(results, output_file, output_format, tree_errors, debug)
+    # Derive the child-analyzer name set from the structural `is_child_analyzer`
+    # marker (see analysis.get_child_analyzer_names) so that output formatting routes
+    # nested children correctly even when a user-authored top-level dynamic def has a
+    # name containing `.methods.`/`.fields.`/`.exports.`. The substring heuristic that
+    # `flatten_analyzer_results` would otherwise fall back to gets that edge case wrong.
+    child_analyzer_names = sigmatcher.analysis.get_child_analyzer_names(
+        merged_definitions, cache.get_apktool_cache_dir(), apk_version
+    )
+    _output_results(results, output_file, output_format, tree_errors, debug, child_analyzer_names)
     return results
 
 

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -25,6 +25,7 @@ from sigmatcher.definitions import (
     ClassDefinition,
     TopLevelDefinition,
     merge_definitions_groups,
+    validate_definitions,
 )
 from sigmatcher.errors import FailedDependencyError, SigmatcherError
 from sigmatcher.formats import MappingFormat, convert_to_format, parse_from_format
@@ -218,7 +219,11 @@ def _read_definitions(signatures: list[Path]) -> tuple[TopLevelDefinition, ...]:
                 other_defs.append(definition)
         class_groups.append(tuple(per_file_classes))
     merged_classes = merge_definitions_groups(class_groups)
-    return (*merged_classes, *other_defs)
+    merged = (*merged_classes, *other_defs)
+    # Cross-definition checks (forbid macros pointing at dynamic defs, etc.) run after
+    # merging so they see the final shape the analyzer will consume.
+    validate_definitions(merged)
+    return merged
 
 
 def _output_successful_results(

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -20,7 +20,12 @@ import sigmatcher.analysis
 from sigmatcher import __version__
 from sigmatcher.analysis import ResultsMapType
 from sigmatcher.cache import DEFAULT_CACHE_DIR_PATH, Cache
-from sigmatcher.definitions import DEFINITIONS_TYPE_ADAPTER, ClassDefinition, merge_definitions_groups
+from sigmatcher.definitions import (
+    DEFINITIONS_TYPE_ADAPTER,
+    ClassDefinition,
+    TopLevelDefinition,
+    merge_definitions_groups,
+)
 from sigmatcher.errors import FailedDependencyError, SigmatcherError
 from sigmatcher.formats import MappingFormat, convert_to_format, parse_from_format
 from sigmatcher.input_paths import validate_input_path
@@ -190,14 +195,30 @@ def convert(
         _ = output_file.write_text(mapping_output)
 
 
-def _read_definitions(signatures: list[Path]) -> tuple[ClassDefinition, ...]:
-    definition_groups: list[tuple[ClassDefinition, ...]] = []
+def _read_definitions(signatures: list[Path]) -> tuple[TopLevelDefinition, ...]:
+    """Load and merge all signature YAML files.
+
+    Each YAML is a list of top-level definitions discriminated by `type`. Missing
+    `type` defaults to "class" so existing v1.x signature files (a bare list of
+    class defs) keep working. Definitions are merged across files by (kind, name);
+    method/field/export top-level kinds do not currently collide with class kinds
+    by accident because they live in separate dispatch buckets.
+    """
+    class_groups: list[tuple[ClassDefinition, ...]] = []
+    other_defs: list[TopLevelDefinition] = []
     for signature_file in signatures:
         with signature_file.open("r") as f:
             raw_yaml = yaml.safe_load(f)  # pyright: ignore[reportAny]
             definitions = DEFINITIONS_TYPE_ADAPTER.validate_python(raw_yaml)
-        definition_groups.append(tuple(definitions))
-    return merge_definitions_groups(definition_groups)
+        per_file_classes: list[ClassDefinition] = []
+        for definition in definitions:
+            if isinstance(definition, ClassDefinition):
+                per_file_classes.append(definition)
+            else:
+                other_defs.append(definition)
+        class_groups.append(tuple(per_file_classes))
+    merged_classes = merge_definitions_groups(class_groups)
+    return (*merged_classes, *other_defs)
 
 
 def _output_successful_results(
@@ -345,6 +366,10 @@ def analyze(  # noqa: PLR0913
         progress_console.quiet = True
 
     merged_definitions = _read_definitions(signatures)
+    # Top-level non-class definitions are validated and round-tripped, but not yet wired
+    # into the analyzer here — the dynamic Method/Field/Export top-level analyzers ship
+    # in a follow-up commit. Filter to class defs for now so analysis still runs.
+    class_definitions = tuple(d for d in merged_definitions if isinstance(d, ClassDefinition))
     cache = Cache.get_from_input(cache_dir, app_input)
     with progress_console.status("Unpacking APK..."):
         unpack_input(apktool, app_input, cache, suppress_output=not debug)
@@ -368,7 +393,7 @@ def analyze(  # noqa: PLR0913
         observer = RichProgressObserver(analysis_progress)
 
     with analysis_progress:
-        results = sigmatcher.analysis.analyze(merged_definitions, cache, apk_version, observer)
+        results = sigmatcher.analysis.analyze(class_definitions, cache, apk_version, observer)
 
     _output_results(results, output_file, output_format, tree_errors, debug)
     return results

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -27,7 +27,7 @@ from sigmatcher.definitions import (
     merge_definitions_groups,
     validate_definitions,
 )
-from sigmatcher.errors import FailedDependencyError, SigmatcherError
+from sigmatcher.errors import DuplicateTopLevelDefinitionError, FailedDependencyError, SigmatcherError
 from sigmatcher.formats import MappingFormat, convert_to_format, flatten_analyzer_results, parse_from_format
 from sigmatcher.input_paths import validate_input_path
 from sigmatcher.results import MatchedClass, Result
@@ -201,12 +201,14 @@ def _read_definitions(signatures: list[Path]) -> tuple[TopLevelDefinition, ...]:
 
     Each YAML is a list of top-level definitions discriminated by `type`. Missing
     `type` defaults to "class" so existing v1.x signature files (a bare list of
-    class defs) keep working. Definitions are merged across files by (kind, name);
-    method/field/export top-level kinds do not currently collide with class kinds
-    by accident because they live in separate dispatch buckets.
+    class defs) keep working. Class definitions are merged across files by name via
+    `merge_definitions_groups`; top-level method/field/export defs are not merged —
+    duplicates across files raise `DuplicateTopLevelDefinitionError` (a hard error,
+    matching the "fail loud on authoring bugs" principle elsewhere in the project).
     """
     class_groups: list[tuple[ClassDefinition, ...]] = []
     other_defs: list[TopLevelDefinition] = []
+    other_defs_seen: dict[tuple[str, str], str] = {}
     for signature_file in signatures:
         with signature_file.open("r") as f:
             raw_yaml = yaml.safe_load(f)  # pyright: ignore[reportAny]
@@ -216,6 +218,11 @@ def _read_definitions(signatures: list[Path]) -> tuple[TopLevelDefinition, ...]:
             if isinstance(definition, ClassDefinition):
                 per_file_classes.append(definition)
             else:
+                kind = getattr(definition, "type", definition.__class__.__name__)
+                key = (str(kind), definition.name)
+                if key in other_defs_seen:
+                    raise DuplicateTopLevelDefinitionError(definition.name, str(kind))
+                other_defs_seen[key] = str(signature_file)
                 other_defs.append(definition)
         class_groups.append(tuple(per_file_classes))
     merged_classes = merge_definitions_groups(class_groups)

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -18,12 +18,13 @@ from rich.tree import Tree
 
 import sigmatcher.analysis
 from sigmatcher import __version__
+from sigmatcher.analysis import ResultsMapType
 from sigmatcher.cache import DEFAULT_CACHE_DIR_PATH, Cache
 from sigmatcher.definitions import DEFINITIONS_TYPE_ADAPTER, ClassDefinition, merge_definitions_groups
 from sigmatcher.errors import FailedDependencyError, SigmatcherError
 from sigmatcher.formats import MappingFormat, convert_to_format, parse_from_format
 from sigmatcher.input_paths import validate_input_path
-from sigmatcher.results import MatchedClass, Result
+from sigmatcher.results import MatchedClass
 from sigmatcher.unpack import get_apk_version, unpack_input
 
 if sys.version_info >= (3, 12):
@@ -251,7 +252,7 @@ def _output_failed_results_tree(failed_results: dict[str, SigmatcherError], debu
 
 
 def _output_results(
-    results: dict[str, Result | SigmatcherError],
+    results: ResultsMapType,
     output_file: Path | None,
     output_format: MappingFormat,
     output_errors_as_tree: bool,
@@ -263,8 +264,10 @@ def _output_results(
     for analyzer_name, result in results.items():
         if isinstance(result, SigmatcherError):
             failed_results[analyzer_name] = result
-        elif isinstance(result, MatchedClass):
-            successful_results[analyzer_name] = result
+            continue
+        for entry in result:
+            if isinstance(entry, MatchedClass):
+                successful_results[analyzer_name] = entry
 
     _output_successful_results(successful_results, output_file, output_format)
     if not failed_results:
@@ -334,7 +337,7 @@ def analyze(  # noqa: PLR0913
     no_progress: Annotated[
         bool, typer.Option(help="Disable progress bars indicating how much of the analysis has been completed.")
     ] = False,
-) -> dict[str, Result | SigmatcherError]:
+) -> ResultsMapType:
     """
     Analyze an APK input using the provided signatures.
     """

--- a/src/sigmatcher/cli.py
+++ b/src/sigmatcher/cli.py
@@ -28,9 +28,9 @@ from sigmatcher.definitions import (
     validate_definitions,
 )
 from sigmatcher.errors import FailedDependencyError, SigmatcherError
-from sigmatcher.formats import MappingFormat, convert_to_format, parse_from_format
+from sigmatcher.formats import MappingFormat, convert_to_format, flatten_analyzer_results, parse_from_format
 from sigmatcher.input_paths import validate_input_path
-from sigmatcher.results import MatchedClass
+from sigmatcher.results import MatchedClass, Result
 from sigmatcher.unpack import get_apk_version, unpack_input
 
 if sys.version_info >= (3, 12):
@@ -284,18 +284,17 @@ def _output_results(
     output_errors_as_tree: bool,
     debug: bool,
 ) -> None:
-    successful_results: dict[str, MatchedClass] = {}
+    successful_lists: dict[str, list[Result]] = {}
     failed_results: dict[str, SigmatcherError] = {}
 
     for analyzer_name, result in results.items():
         if isinstance(result, SigmatcherError):
             failed_results[analyzer_name] = result
             continue
-        for entry in result:
-            if isinstance(entry, MatchedClass):
-                successful_results[analyzer_name] = entry
+        successful_lists[analyzer_name] = result
 
-    _output_successful_results(successful_results, output_file, output_format)
+    flattened = flatten_analyzer_results(successful_lists)
+    _output_successful_results(flattened, output_file, output_format)
     if not failed_results:
         return
     if output_errors_as_tree:

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -330,13 +330,21 @@ def merge_definition(def1: TDefinition, def2: TDefinition) -> TDefinition:
 
     if isinstance(def1, ClassDefinition):
         assert isinstance(def2, ClassDefinition)
-        return def1.model_copy(  # pyrefly: ignore[bad-return] related to https://github.com/facebook/pyrefly/issues/1274
+        # Re-validate via model_validate so model-level validators (e.g. the
+        # dynamic_name consistency check) run on the merged definition.
+        # model_copy alone bypasses validators, which would let a merged
+        # ClassDefinition end up with a `(?P<class_name>...)` group but
+        # dynamic_name=False, silently disabling capture.
+        merged = def1.model_copy(
             update={
                 "signatures": signatures,
                 "methods": merge_definitions_groups([def1.methods, def2.methods]),
                 "fields": merge_definitions_groups([def1.fields, def2.fields]),
                 "exports": merge_definitions_groups([def1.exports, def2.exports]),
             }
+        )
+        return type(def1).model_validate(  # pyrefly: ignore[bad-return] related to https://github.com/facebook/pyrefly/issues/1274
+            merged, from_attributes=True
         )
     return def1.model_copy(update={"signatures": signatures})
 

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, ClassVar, Literal, TypeAlias, TypeVar
+from typing import Annotated, Any, ClassVar, Literal, Protocol, TypeAlias, TypeVar
 
 import pydantic
 from packaging.specifiers import SpecifierSet
@@ -287,7 +287,48 @@ class MethodDefinition(Definition, frozen=True):
     pass
 
 
+class _DynamicNameValidatable(Protocol):
+    """Structural protocol describing the attributes the dynamic_name validator reads.
+
+    Used purely for typing — the actual fields are declared on each concrete model.
+    """
+
+    @property
+    def name(self) -> str: ...
+    @property
+    def dynamic_name(self) -> bool: ...
+    @property
+    def signatures(self) -> tuple[Signature, ...]: ...
+
+
+def _validate_dynamic_name_group(model: _DynamicNameValidatable, axis_label: str, capture_group_name: str) -> None:
+    """Enforce that `dynamic_name` matches the presence of the axis-specific named group.
+
+    Each axis (class / method / field / export) uses a different named capture group
+    (`class_name`, `method_name`, ...). Centralized so the four subclasses all share
+    one set of error messages.
+    """
+    has_group = any(
+        isinstance(sig, BaseRegexSignature) and capture_group_name in sig.signature.groupindex
+        for sig in model.signatures
+    )
+    if model.dynamic_name and not has_group:
+        raise ValueError(
+            f"{type(model).__name__} {model.name!r} has dynamic_name=True but no signature "
+            f"contains a (?P<{capture_group_name}>...) named group."
+        )
+    if not model.dynamic_name and has_group:
+        raise ValueError(
+            f"{type(model).__name__} {model.name!r} contains a (?P<{capture_group_name}>...) named group "
+            f"but dynamic_name is not set. Set dynamic_name: true to enable capturing "
+            f"the {axis_label} name from the signature."
+        )
+
+
 class ClassDefinition(Definition, frozen=True):
+    type: Literal["class"] = "class"
+    """The top-level definition kind. Defaults to "class" so existing signature
+    files without a `type:` discriminator still validate."""
     package: str | None = None
     """The package of the class."""
     fields: tuple[FieldDefinition, ...] = ()
@@ -304,23 +345,80 @@ class ClassDefinition(Definition, frozen=True):
 
     @pydantic.model_validator(mode="after")
     def _check_dynamic_name_group(self) -> Self:
-        # Only regex/glob signatures carry Python named groups today; TreeSitterSignature is skipped here.
-        has_group = any(isinstance(sig, BaseRegexSignature) and sig.has_class_name_group() for sig in self.signatures)
-        if self.dynamic_name and not has_group:
-            raise ValueError(
-                f"ClassDefinition {self.name!r} has dynamic_name=True but no signature "
-                f"contains a (?P<class_name>...) named group."
-            )
-        if not self.dynamic_name and has_group:
-            raise ValueError(
-                f"ClassDefinition {self.name!r} contains a (?P<class_name>...) named group "
-                f"but dynamic_name is not set. Set dynamic_name: true to enable capturing "
-                f"the class name from the signature."
-            )
+        _validate_dynamic_name_group(self, "class", "class_name")
         return self
 
 
-DEFINITIONS_TYPE_ADAPTER = pydantic.TypeAdapter(list[ClassDefinition])
+class TopLevelMethodDefinition(MethodDefinition, frozen=True):
+    """A top-level method definition. Scans the entire smali corpus and produces
+    zero or more MatchedMethod results, one per occurrence. The readable name comes
+    from a `(?P<method_name>...)` capture group when `dynamic_name` is true."""
+
+    type: Literal["method"] = "method"
+    """The top-level definition kind."""
+    dynamic_name: bool = False
+    """If true, capture the readable method name from a `(?P<method_name>...)` named group."""
+
+    @pydantic.model_validator(mode="after")
+    def _check_dynamic_name_group(self) -> Self:
+        _validate_dynamic_name_group(self, "method", "method_name")
+        return self
+
+
+class TopLevelFieldDefinition(FieldDefinition, frozen=True):
+    """A top-level field definition. Scans the entire smali corpus and produces
+    zero or more MatchedField results. The readable name comes from a
+    `(?P<field_name>...)` capture group when `dynamic_name` is true."""
+
+    type: Literal["field"] = "field"
+    """The top-level definition kind."""
+    dynamic_name: bool = False
+    """If true, capture the readable field name from a `(?P<field_name>...)` named group."""
+
+    @pydantic.model_validator(mode="after")
+    def _check_dynamic_name_group(self) -> Self:
+        _validate_dynamic_name_group(self, "field", "field_name")
+        return self
+
+
+class TopLevelExportDefinition(ExportDefinition, frozen=True):
+    """A top-level export definition. Scans the entire smali corpus and produces
+    zero or more MatchedExport results. The readable name comes from a
+    `(?P<export_name>...)` capture group when `dynamic_name` is true."""
+
+    type: Literal["export"] = "export"
+    """The top-level definition kind."""
+    dynamic_name: bool = False
+    """If true, capture the readable export name from a `(?P<export_name>...)` named group."""
+
+    @pydantic.model_validator(mode="after")
+    def _check_dynamic_name_group(self) -> Self:
+        _validate_dynamic_name_group(self, "export", "export_name")
+        return self
+
+
+def _top_level_type_discriminator(value: Any) -> str:  # noqa: ANN401
+    """Return the discriminator value for a top-level definition entry.
+
+    Accepts dict input (from YAML parsing) or already-validated model instances.
+    Missing `type` defaults to "class" so a bare list of class defs (the v1.x
+    format) still validates.
+    """
+    if isinstance(value, dict):
+        return str(value.get("type", "class"))
+    return str(getattr(value, "type", "class"))
+
+
+TopLevelDefinition: TypeAlias = Annotated[
+    Annotated[ClassDefinition, pydantic.Tag("class")]
+    | Annotated[TopLevelMethodDefinition, pydantic.Tag("method")]
+    | Annotated[TopLevelFieldDefinition, pydantic.Tag("field")]
+    | Annotated[TopLevelExportDefinition, pydantic.Tag("export")],
+    pydantic.Discriminator(_top_level_type_discriminator),
+]
+
+
+DEFINITIONS_TYPE_ADAPTER = pydantic.TypeAdapter(list[TopLevelDefinition])
 SIGNATURES_TYPE_ADAPTER = pydantic.TypeAdapter(tuple[Signature, ...])
 
 TDefinition = TypeVar("TDefinition", bound=Definition)

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -349,18 +349,37 @@ class ClassDefinition(Definition, frozen=True):
         return self
 
 
+def _require_dynamic_name_for_top_level(model: _DynamicNameValidatable, axis_label: str) -> None:
+    """Top-level method/field/export defs only make sense in the dynamic_name=True shape.
+
+    Static methods/fields/exports must be declared as children of a class definition —
+    that's the documented path. A `dynamic_name=False` top-level def has no readable
+    name to capture and no parent class to attach to, so it would silently produce no
+    useful output. Reject it at validation time instead.
+    """
+    if not model.dynamic_name:
+        raise ValueError(
+            f"{type(model).__name__} {model.name!r} has dynamic_name=False. Top-level "
+            f"{axis_label} definitions must set dynamic_name: true and include a "
+            f"(?P<{axis_label}_name>...) capture group; static {axis_label}s should be "
+            "declared as children of a class definition instead."
+        )
+
+
 class TopLevelMethodDefinition(MethodDefinition, frozen=True):
     """A top-level method definition. Scans the entire smali corpus and produces
     zero or more MatchedMethod results, one per occurrence. The readable name comes
-    from a `(?P<method_name>...)` capture group when `dynamic_name` is true."""
+    from a `(?P<method_name>...)` capture group; `dynamic_name` must be true."""
 
     type: Literal["method"] = "method"
     """The top-level definition kind."""
     dynamic_name: bool = False
-    """If true, capture the readable method name from a `(?P<method_name>...)` named group."""
+    """If true, capture the readable method name from a `(?P<method_name>...)` named group.
+    Top-level method definitions must set this to true — see the validator below."""
 
     @pydantic.model_validator(mode="after")
     def _check_dynamic_name_group(self) -> Self:
+        _require_dynamic_name_for_top_level(self, "method")
         _validate_dynamic_name_group(self, "method", "method_name")
         return self
 
@@ -368,15 +387,17 @@ class TopLevelMethodDefinition(MethodDefinition, frozen=True):
 class TopLevelFieldDefinition(FieldDefinition, frozen=True):
     """A top-level field definition. Scans the entire smali corpus and produces
     zero or more MatchedField results. The readable name comes from a
-    `(?P<field_name>...)` capture group when `dynamic_name` is true."""
+    `(?P<field_name>...)` capture group; `dynamic_name` must be true."""
 
     type: Literal["field"] = "field"
     """The top-level definition kind."""
     dynamic_name: bool = False
-    """If true, capture the readable field name from a `(?P<field_name>...)` named group."""
+    """If true, capture the readable field name from a `(?P<field_name>...)` named group.
+    Top-level field definitions must set this to true — see the validator below."""
 
     @pydantic.model_validator(mode="after")
     def _check_dynamic_name_group(self) -> Self:
+        _require_dynamic_name_for_top_level(self, "field")
         _validate_dynamic_name_group(self, "field", "field_name")
         return self
 
@@ -384,15 +405,17 @@ class TopLevelFieldDefinition(FieldDefinition, frozen=True):
 class TopLevelExportDefinition(ExportDefinition, frozen=True):
     """A top-level export definition. Scans the entire smali corpus and produces
     zero or more MatchedExport results. The readable name comes from a
-    `(?P<export_name>...)` capture group when `dynamic_name` is true."""
+    `(?P<export_name>...)` capture group; `dynamic_name` must be true."""
 
     type: Literal["export"] = "export"
     """The top-level definition kind."""
     dynamic_name: bool = False
-    """If true, capture the readable export name from a `(?P<export_name>...)` named group."""
+    """If true, capture the readable export name from a `(?P<export_name>...)` named group.
+    Top-level export definitions must set this to true — see the validator below."""
 
     @pydantic.model_validator(mode="after")
     def _check_dynamic_name_group(self) -> Self:
+        _require_dynamic_name_for_top_level(self, "export")
         _validate_dynamic_name_group(self, "export", "export_name")
         return self
 

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -448,6 +448,60 @@ def merge_definition(def1: TDefinition, def2: TDefinition) -> TDefinition:
     return def1.model_copy(update={"signatures": signatures})
 
 
+def _collect_dynamic_definition_names(definitions: Sequence["TopLevelDefinition"]) -> set[str]:
+    """Return the set of top-level definitions that have `dynamic_name=True`.
+
+    Used by the load-time validator to forbid macros that reference dynamic definitions.
+    """
+    dynamic_names: set[str] = set()
+    for definition in definitions:
+        if getattr(definition, "dynamic_name", False):
+            dynamic_names.add(definition.name)
+    return dynamic_names
+
+
+def _macro_subjects_for_definition(definition: "TopLevelDefinition") -> set[str]:
+    """Collect every macro subject referenced anywhere inside a top-level definition.
+
+    Includes the top-level definition's own signatures and, for class definitions, the
+    signatures of nested method / field / export defs. Macro subjects are dotted
+    accessor paths (`Parent.fields.foo`); we keep just the root identifier here since
+    that is what the dynamic-name forbid rule cares about.
+    """
+    subjects: set[str] = set()
+
+    def _add_from(defn: Definition) -> None:
+        for signature in defn.signatures:
+            for macro in signature.get_macro_definitions():
+                root, _, _ = macro.subject.partition(".")
+                subjects.add(root)
+
+    _add_from(definition)
+    if isinstance(definition, ClassDefinition):
+        for nested in (*definition.methods, *definition.fields, *definition.exports):
+            _add_from(nested)
+    return subjects
+
+
+def validate_definitions(definitions: Sequence["TopLevelDefinition"]) -> None:
+    """Cross-definition validation that runs after merge_definitions_groups.
+
+    Raises sigmatcher.errors.MacroPointsToDynamicError if any definition's signatures
+    reference a dynamic definition via a macro — see decision #4 in the redesign.
+    """
+    # Local import to avoid a hard cycle (errors imports MacroStatement only behind
+    # TYPE_CHECKING, so the runtime cycle is one-way: definitions -> errors).
+    from sigmatcher.errors import MacroPointsToDynamicError  # noqa: PLC0415
+
+    dynamic_names = _collect_dynamic_definition_names(definitions)
+    if not dynamic_names:
+        return
+    for definition in definitions:
+        for subject in _macro_subjects_for_definition(definition):
+            if subject in dynamic_names:
+                raise MacroPointsToDynamicError(definition.name, subject)
+
+
 def merge_definitions_groups(definition_groups: Sequence[Sequence[TDefinition]]) -> tuple[TDefinition, ...]:
     """
     Merge multiple definition groups into a single group,

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -155,6 +155,18 @@ class BaseRegexSignature(BaseSignature, frozen=True):
 
         return set(match.groups())
 
+    def has_class_name_group(self) -> bool:
+        return "class_name" in self.signature.groupindex
+
+    def capture_class_name(self, value: str) -> set[str]:
+        captures: set[str] = set()
+        for match in self.signature.finditer(value):
+            try:
+                captures.add(match.group("class_name"))
+            except IndexError:
+                continue
+        return captures
+
     @override
     def get_dependencies(self) -> list[str]:
         return [macro.subject for macro in self.get_macro_definitions()]
@@ -284,6 +296,27 @@ class ClassDefinition(Definition, frozen=True):
     """A list of method definitions."""
     exports: tuple[ExportDefinition, ...] = ()
     """A list of export definitions."""
+    dynamic_name: bool = False
+    """If true, capture the readable class name from a `(?P<class_name>...)` named group
+    in one of the signatures. The YAML `name` is the placeholder used for macros,
+    caching, and dependency-graph identity; the captured value becomes the readable
+    `original.name` in the result and is what shows up in output mapping formats."""
+
+    @pydantic.model_validator(mode="after")
+    def _check_dynamic_name_group(self) -> Self:
+        has_group = any(isinstance(sig, BaseRegexSignature) and sig.has_class_name_group() for sig in self.signatures)
+        if self.dynamic_name and not has_group:
+            raise ValueError(
+                f"ClassDefinition {self.name!r} has dynamic_name=True but no signature "
+                f"contains a (?P<class_name>...) named group."
+            )
+        if not self.dynamic_name and has_group:
+            raise ValueError(
+                f"ClassDefinition {self.name!r} contains a (?P<class_name>...) named group "
+                f"but dynamic_name is not set. Set dynamic_name: true to enable capturing "
+                f"the class name from the signature."
+            )
+        return self
 
 
 DEFINITIONS_TYPE_ADAPTER = pydantic.TypeAdapter(list[ClassDefinition])

--- a/src/sigmatcher/definitions.py
+++ b/src/sigmatcher/definitions.py
@@ -304,6 +304,7 @@ class ClassDefinition(Definition, frozen=True):
 
     @pydantic.model_validator(mode="after")
     def _check_dynamic_name_group(self) -> Self:
+        # Only regex/glob signatures carry Python named groups today; TreeSitterSignature is skipped here.
         has_group = any(isinstance(sig, BaseRegexSignature) and sig.has_class_name_group() for sig in self.signatures)
         if self.dynamic_name and not has_group:
             raise ValueError(

--- a/src/sigmatcher/errors.py
+++ b/src/sigmatcher/errors.py
@@ -122,6 +122,30 @@ class FailedDependencyError(DependencyError):
         return "Skipped because of failed dependencies"
 
 
+class MacroPointsToDynamicError(SigmatcherError):
+    """
+    Raised at signature-file load time when a macro `${X.<property>}` references a
+    definition `X` whose `dynamic_name` flag is set.
+
+    Dynamic definitions emit 0+ matches per run, so a macro that needs a single concrete
+    value (`X.java`, `X.full_name`, etc.) cannot be resolved unambiguously. This is a
+    hard error, not a per-analyzer failure, so authors see the problem at load time
+    instead of after analysis runs.
+    """
+
+    def __init__(self, analyzer_name: str, dynamic_dependency: str, *args: object) -> None:
+        self.dynamic_dependency: str = dynamic_dependency
+        super().__init__(analyzer_name, dynamic_dependency, *args)
+
+    @override
+    def short_message(self) -> str:
+        return (
+            f"Definition {self.analyzer_name!r} references dynamic definition "
+            f"{self.dynamic_dependency!r} via a macro, which is not allowed: dynamic "
+            "definitions emit 0+ matches and cannot be macro-resolved to a single value."
+        )
+
+
 class MissingClassNameGroupError(SigmatcherError):
     """
     Raised when a ClassDefinition has dynamic_name=True but none of the signatures

--- a/src/sigmatcher/errors.py
+++ b/src/sigmatcher/errors.py
@@ -171,28 +171,33 @@ class MacroPointsToDynamicError(SigmatcherError):
         )
 
 
-class MissingClassNameGroupError(SigmatcherError):
+class MissingDynamicCaptureGroupError(SigmatcherError):
     """
-    Raised when a ClassDefinition has dynamic_name=True but none of the signatures
-    applicable to the current app version carries the (?P<class_name>...) named
-    group used to capture the readable class name.
+    Raised when a definition has dynamic_name=True but none of the signatures
+    applicable to the current app version carries the axis-specific named group
+    (`class_name`, `method_name`, `field_name`, `export_name`) used to capture the
+    readable name.
 
     This can happen even when the model-level validator passed, because the
     validator inspects all signatures while the analyzer iterates only the
     version-filtered subset.
     """
 
-    def __init__(self, analyzer_name: str, app_version: str | None, *args: object) -> None:
+    def __init__(
+        self, analyzer_name: str, app_version: str | None, axis_label: str, capture_group_name: str, *args: object
+    ) -> None:
         self.app_version: str | None = app_version
-        super().__init__(analyzer_name, app_version, *args)
+        self.axis_label: str = axis_label
+        self.capture_group_name: str = capture_group_name
+        super().__init__(analyzer_name, app_version, axis_label, capture_group_name, *args)
 
     @override
     def short_message(self) -> str:
         return (
-            f"ClassDefinition {self.analyzer_name!r} has dynamic_name=True but no signature "
-            f"applicable to app version {self.app_version!r} contains a (?P<class_name>...) "
-            "named group. Add a class_name capture to a signature whose version_range covers "
-            "this version."
+            f"Definition {self.analyzer_name!r} has dynamic_name=True but no signature "
+            f"applicable to app version {self.app_version!r} contains a "
+            f"(?P<{self.capture_group_name}>...) named group. Add a {self.capture_group_name} "
+            f"capture to a {self.axis_label} signature whose version_range covers this version."
         )
 
 

--- a/src/sigmatcher/errors.py
+++ b/src/sigmatcher/errors.py
@@ -122,6 +122,31 @@ class FailedDependencyError(DependencyError):
         return "Skipped because of failed dependencies"
 
 
+class MissingClassNameGroupError(SigmatcherError):
+    """
+    Raised when a ClassDefinition has dynamic_name=True but none of the signatures
+    applicable to the current app version carries the (?P<class_name>...) named
+    group used to capture the readable class name.
+
+    This can happen even when the model-level validator passed, because the
+    validator inspects all signatures while the analyzer iterates only the
+    version-filtered subset.
+    """
+
+    def __init__(self, analyzer_name: str, app_version: str | None, *args: object) -> None:
+        self.app_version: str | None = app_version
+        super().__init__(analyzer_name, app_version, *args)
+
+    @override
+    def short_message(self) -> str:
+        return (
+            f"ClassDefinition {self.analyzer_name!r} has dynamic_name=True but no signature "
+            f"applicable to app version {self.app_version!r} contains a (?P<class_name>...) "
+            "named group. Add a class_name capture to a signature whose version_range covers "
+            "this version."
+        )
+
+
 class InvalidMacroModifierError(SigmatcherError):
     """
     Exception raised when an invalid macro modifier is encountered.

--- a/src/sigmatcher/errors.py
+++ b/src/sigmatcher/errors.py
@@ -201,6 +201,89 @@ class MissingDynamicCaptureGroupError(SigmatcherError):
         )
 
 
+class ChildFailedForParentError(SigmatcherError):
+    """
+    Raised when a child analyzer (method/field/export) fails for one specific
+    parent class match among the N parents produced by a dynamic class def.
+
+    The all-or-nothing rule (decision #6) treats a single per-parent failure as a
+    failure of the whole child analyzer — every successful per-parent match is
+    discarded. This error wraps the underlying SigmatcherError so callers see
+    *which* parent caused the failure rather than a bare child-analyzer name.
+    """
+
+    def __init__(
+        self,
+        analyzer_name: str,
+        parent_class_java: str,
+        underlying_error: SigmatcherError,
+        *args: object,
+    ) -> None:
+        self.parent_class_java: str = parent_class_java
+        self.underlying_error: SigmatcherError = underlying_error
+        super().__init__(analyzer_name, parent_class_java, underlying_error, *args)
+
+    @override
+    def short_message(self) -> str:
+        return f"Failed for parent class {self.parent_class_java!r}: {self.underlying_error.short_message()}"
+
+    @override
+    def debug_message(self) -> str:
+        underlying_debug = self.underlying_error.debug_message()
+        prefix = f"Parent class: {self.parent_class_java}"
+        if not underlying_debug:
+            return prefix
+        return f"{prefix}\n{underlying_debug}"
+
+
+class UnexpectedMultiResultMacroError(SigmatcherError):
+    """
+    Raised when a macro tries to resolve against a result list that does not contain
+    exactly one entry.
+
+    Under normal operation the load-time `validate_definitions` pass forbids macros
+    pointing at dynamic definitions, so every macro subject resolves to a singleton
+    list. This error guards the programmatic API path (`sigmatcher.analysis.analyze`
+    called directly without the CLI's `_read_definitions` wrapper), where the
+    upstream validator was previously skipped — callers would otherwise crash with
+    a bare `AssertionError` instead of a `SigmatcherError`.
+    """
+
+    def __init__(self, analyzer_name: str, macro_subject: str, result_count: int, *args: object) -> None:
+        self.macro_subject: str = macro_subject
+        self.result_count: int = result_count
+        super().__init__(analyzer_name, macro_subject, result_count, *args)
+
+    @override
+    def short_message(self) -> str:
+        return (
+            f"Macro subject {self.macro_subject!r} resolved to {self.result_count} matches, "
+            "expected exactly one. Macros against dynamic definitions are forbidden — "
+            "make sure validate_definitions has been called on this definition set."
+        )
+
+
+class DuplicateTopLevelDefinitionError(SigmatcherError):
+    """
+    Raised when two signature files declare a top-level definition with the same
+    `(kind, name)`. Class definitions are merged by `merge_definitions_groups`, but
+    top-level method/field/export defs are not, so a duplicate would silently overwrite
+    the first. Surface this as a hard load-time error instead.
+    """
+
+    def __init__(self, definition_name: str, definition_kind: str, *args: object) -> None:
+        self.definition_kind: str = definition_kind
+        super().__init__(definition_name, definition_kind, *args)
+
+    @override
+    def short_message(self) -> str:
+        return (
+            f"Duplicate top-level {self.definition_kind} definition {self.analyzer_name!r} found "
+            "across signature files. Top-level method/field/export definitions are not merged — "
+            "rename one or move them into the same file with merge-friendly semantics."
+        )
+
+
 class InvalidMacroModifierError(SigmatcherError):
     """
     Exception raised when an invalid macro modifier is encountered.

--- a/src/sigmatcher/errors.py
+++ b/src/sigmatcher/errors.py
@@ -122,6 +122,31 @@ class FailedDependencyError(DependencyError):
         return "Skipped because of failed dependencies"
 
 
+class DuplicateCapturedNameError(SigmatcherError):
+    """
+    Raised when emitting an output format and two different definitions produce
+    MatchedClass entries with the same readable `original.name`.
+
+    Output keys (raw/enigma/legacy/jadx) are derived from `original.name`, so a
+    collision would silently overwrite one of the entries. The redesign locks this
+    as a hard error (decision #9) so authors disambiguate explicitly.
+    """
+
+    def __init__(self, captured_name: str, first_analyzer: str, second_analyzer: str, *args: object) -> None:
+        self.captured_name: str = captured_name
+        self.first_analyzer: str = first_analyzer
+        self.second_analyzer: str = second_analyzer
+        super().__init__(first_analyzer, captured_name, second_analyzer, *args)
+
+    @override
+    def short_message(self) -> str:
+        return (
+            f"Two definitions captured the same readable name {self.captured_name!r}: "
+            f"{self.first_analyzer!r} and {self.second_analyzer!r}. Tighten one of the "
+            "signatures so the captures disambiguate."
+        )
+
+
 class MacroPointsToDynamicError(SigmatcherError):
     """
     Raised at signature-file load time when a macro `${X.<property>}` references a

--- a/src/sigmatcher/formats.py
+++ b/src/sigmatcher/formats.py
@@ -8,7 +8,17 @@ from typing import ClassVar, Literal
 import pydantic
 import pydantic.alias_generators
 
-from sigmatcher.results import Class, Field, MatchedClass, MatchedField, MatchedMethod, Method
+from sigmatcher.errors import DuplicateCapturedNameError
+from sigmatcher.results import (
+    Class,
+    Field,
+    MatchedClass,
+    MatchedExport,
+    MatchedField,
+    MatchedMethod,
+    Method,
+    Result,
+)
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -32,12 +42,16 @@ class RawFormatter(Formatter):
     @override
     def convert(self, matched_classes: dict[str, MatchedClass]) -> str:
         # Serialize each class on its own to exclude the smali_file field, instead of using a RootModel because of https://github.com/pydantic/pydantic/discussions/11383
+        # Output keys come from the captured `original.name` (decision #9). The
+        # caller (cli._output_results) builds the input dict via
+        # flatten_analyzer_results which already keys by captured name.
         return json.dumps(
             {
                 key: matched_class.model_dump(mode="dict", exclude={"smali_file"})
                 for key, matched_class in matched_classes.items()
             },
             indent=4,
+            sort_keys=True,
         )
 
 
@@ -280,6 +294,99 @@ class JadxParser(Parser):
         self._parse_fields(result, jadx_to_sigma_classes, jadx_to_sigma_field)
         self._parse_methods(result, jadx_to_sigma_classes, jadx_to_sigma_method)
         return result
+
+
+def flatten_analyzer_results(
+    analyzer_results: "dict[str, list[Result]]",
+) -> dict[str, MatchedClass]:
+    """Flatten the per-analyzer list-of-results into the flat shape output formats use.
+
+    - MatchedClass entries are keyed by `original.name` (the captured / static
+      readable name).
+    - Top-level MatchedMethod/MatchedField/MatchedExport entries (those that carry a
+      non-None `smali_class`) are folded into a synthesized holder-class entry keyed
+      by the parent obfuscated class's readable form, so the format contract stays
+      "one MatchedClass per top-level key" (decision #10).
+    - If two analyzers produce MatchedClass entries with the same captured
+      `original.name`, raise DuplicateCapturedNameError (decision #9).
+    """
+    by_captured_name: dict[str, MatchedClass] = {}
+    captured_name_origin: dict[str, str] = {}
+    # Holder classes synthesized for top-level dynamic method/field/export results
+    # are tracked separately so we can attach multiple top-level analyzers' results
+    # to the same obfuscated class without re-triggering the duplicate-name check.
+    holders_by_smali_java: dict[str, MatchedClass] = {}
+
+    for analyzer_name, entries in analyzer_results.items():
+        for entry in entries:
+            if isinstance(entry, MatchedClass):
+                _add_matched_class(entry, analyzer_name, by_captured_name, captured_name_origin)
+            else:
+                _attach_to_holder(entry, holders_by_smali_java)
+
+    for holder in holders_by_smali_java.values():
+        # Holders may share `original.name` with a captured class entry; in that case
+        # we should fold the holder's child results into the existing entry rather
+        # than re-keying. Decision #10 keeps the contract simple: one key per
+        # readable class name.
+        existing = by_captured_name.get(holder.original.name)
+        if existing is None:
+            by_captured_name[holder.original.name] = holder
+            continue
+        existing.matched_methods.extend(holder.matched_methods)
+        existing.matched_fields.extend(holder.matched_fields)
+        existing.exports.extend(holder.exports)
+
+    return by_captured_name
+
+
+def _add_matched_class(
+    entry: MatchedClass,
+    analyzer_name: str,
+    by_captured_name: dict[str, MatchedClass],
+    captured_name_origin: dict[str, str],
+) -> None:
+    captured = entry.original.name
+    if captured in by_captured_name:
+        # Same analyzer emitting multiple holders for the same captured name is fine
+        # (e.g. a dynamic class def that matches multiple smali files but all collapse
+        # to the same readable name) — that case is folded; cross-analyzer collisions
+        # are the actual error.
+        if captured_name_origin[captured] != analyzer_name:
+            raise DuplicateCapturedNameError(captured, captured_name_origin[captured], analyzer_name)
+        existing = by_captured_name[captured]
+        existing.matched_methods.extend(entry.matched_methods)
+        existing.matched_fields.extend(entry.matched_fields)
+        existing.exports.extend(entry.exports)
+        return
+    by_captured_name[captured] = entry
+    captured_name_origin[captured] = analyzer_name
+
+
+def _attach_to_holder(entry: Result, holders_by_smali_java: dict[str, MatchedClass]) -> None:
+    smali_class = getattr(entry, "smali_class", None)
+    if smali_class is None:
+        # Defensive: a non-MatchedClass top-level result without a smali_class has
+        # nowhere to land. Skip rather than synthesize a "unknown" holder.
+        return
+    smali_java = smali_class.to_java_representation()  # pyright: ignore[reportAny]
+    holder = holders_by_smali_java.get(smali_java)
+    if holder is None:
+        assert isinstance(smali_class, Class)
+        holder = MatchedClass(
+            original=smali_class,
+            new=smali_class,
+            matched_methods=[],
+            matched_fields=[],
+            exports=[],
+        )
+        holders_by_smali_java[smali_java] = holder
+    if isinstance(entry, MatchedMethod):
+        holder.matched_methods.append(entry)
+    elif isinstance(entry, MatchedField):
+        holder.matched_fields.append(entry)
+    elif isinstance(entry, MatchedExport):
+        holder.exports.append(entry)
 
 
 class MappingFormat(str, enum.Enum):

--- a/src/sigmatcher/formats.py
+++ b/src/sigmatcher/formats.py
@@ -104,7 +104,10 @@ class EnigmaFormatter(Formatter):
     @override
     def convert(self, matched_classes: dict[str, MatchedClass]) -> str:
         final = StringIO()
-        for matched_class in matched_classes.values():
+        # Sort by readable `original.name` so the output is deterministic across runs
+        # regardless of the analyzer dispatch order. Mirrors `RawFormatter`'s
+        # sort_keys=True and `LegacyFormatter`'s ordering.
+        for matched_class in sorted(matched_classes.values(), key=lambda mc: mc.original.name):
             _ = final.write(self.convert_class(matched_class))
         return final.getvalue()
 
@@ -191,7 +194,10 @@ class JadxFormatter(Formatter):
     @override
     def convert(self, matched_classes: dict[str, MatchedClass]) -> str:
         jadx_project = JadxProjectFile(code_data=JadxCodeData(renames=[]))
-        for matched_class in matched_classes.values():
+        # Sort by readable `original.name` so the output is deterministic across runs
+        # regardless of the analyzer dispatch order. Mirrors `RawFormatter`'s
+        # sort_keys=True and `LegacyFormatter`'s ordering.
+        for matched_class in sorted(matched_classes.values(), key=lambda mc: mc.original.name):
             class_node_ref = JadxNodeRef(ref_type="CLASS", decl_class=matched_class.new.to_full_name())
             class_rename = JadxRename(new_name=matched_class.original.to_full_name(), node_ref=class_node_ref)
             jadx_project.code_data.renames.append(class_rename)

--- a/src/sigmatcher/formats.py
+++ b/src/sigmatcher/formats.py
@@ -304,6 +304,7 @@ class JadxParser(Parser):
 
 def flatten_analyzer_results(
     analyzer_results: "dict[str, list[Result]]",
+    child_analyzer_names: set[str] | None = None,
 ) -> dict[str, MatchedClass]:
     """Flatten the per-analyzer list-of-results into the flat shape output formats use.
 
@@ -314,11 +315,19 @@ def flatten_analyzer_results(
       holder-class entry keyed by the parent obfuscated class's readable form, so
       the format contract stays "one MatchedClass per top-level key" (decision #10).
       Nested children of a class analyzer carry the same Match* types but are
-      identified by their dotted analyzer name (e.g. `Foo.methods.bar`) — those
-      are skipped here because they're already attached to their parent MatchedClass
-      via the parent's `matched_methods` / `matched_fields` / `exports` lists.
+      already attached to their parent MatchedClass via the parent's
+      `matched_methods` / `matched_fields` / `exports` lists — those are identified
+      via the `child_analyzer_names` set (built by the orchestrator from the
+      structural `Analyzer.is_child_analyzer` marker) and skipped.
     - If two analyzers produce MatchedClass entries with the same captured
       `original.name`, raise DuplicateCapturedNameError (decision #9).
+
+    `child_analyzer_names` is optional: when None we fall back to a substring-based
+    heuristic on the analyzer name. The CLI always passes the structural set; the
+    heuristic exists for direct programmatic callers and legacy tests, and intentionally
+    mis-handles user-authored top-level dynamic defs whose YAML name happens to contain
+    `.methods.`/`.fields.`/`.exports.` (those are silently skipped) — so callers that
+    care about that edge case must pass the set.
     """
     by_captured_name: dict[str, MatchedClass] = {}
     captured_name_origin: dict[str, str] = {}
@@ -331,7 +340,7 @@ def flatten_analyzer_results(
         for entry in entries:
             if isinstance(entry, MatchedClass):
                 _add_matched_class(entry, analyzer_name, by_captured_name, captured_name_origin)
-            elif _is_child_analyzer_name(analyzer_name):
+            elif _is_child_analyzer_entry(analyzer_name, child_analyzer_names):
                 # Nested child results are already attached to their parent MatchedClass
                 # (see ChildAnalyzer._update_parent_with_child_result). Skipping them here
                 # avoids duplicating them into a synthesized holder class.
@@ -378,14 +387,22 @@ def _add_matched_class(
     captured_name_origin[captured] = analyzer_name
 
 
-def _is_child_analyzer_name(analyzer_name: str) -> bool:
-    """Return True for dotted child analyzer names (e.g. `Class.methods.foo`).
+def _is_child_analyzer_entry(analyzer_name: str, child_analyzer_names: set[str] | None) -> bool:
+    """Return True if `analyzer_name` belongs to a nested child analyzer.
 
-    The orchestrator uses dotted names exclusively for `ChildAnalyzer` instances
-    (see `FieldAnalyzer.name`, `MethodAnalyzer.name`, `ExportAnalyzer.name`).
-    Top-level analyzers — including top-level dynamic method/field/export — use
-    the raw definition name, which never contains the axis infixes.
+    Preferred path: caller passes `child_analyzer_names`, built from the structural
+    `Analyzer.is_child_analyzer` marker by the orchestrator. That's an exact match —
+    no false positives, no surprises for user-authored top-level dynamic defs whose
+    YAML name contains `.methods.`/`.fields.`/`.exports.`.
+
+    Fallback path: when no set is provided we substring-match the dotted name
+    convention (`FieldAnalyzer.name`, `MethodAnalyzer.name`, `ExportAnalyzer.name`).
+    This path exists so direct callers of `flatten_analyzer_results` (programmatic
+    users, legacy tests) keep working, at the cost of mis-classifying the edge case
+    above. The CLI always passes the structural set.
     """
+    if child_analyzer_names is not None:
+        return analyzer_name in child_analyzer_names
     return ".methods." in analyzer_name or ".fields." in analyzer_name or ".exports." in analyzer_name
 
 

--- a/src/sigmatcher/formats.py
+++ b/src/sigmatcher/formats.py
@@ -303,10 +303,14 @@ def flatten_analyzer_results(
 
     - MatchedClass entries are keyed by `original.name` (the captured / static
       readable name).
-    - Top-level MatchedMethod/MatchedField/MatchedExport entries (those that carry a
-      non-None `smali_class`) are folded into a synthesized holder-class entry keyed
-      by the parent obfuscated class's readable form, so the format contract stays
-      "one MatchedClass per top-level key" (decision #10).
+    - Top-level MatchedMethod/MatchedField/MatchedExport entries (those produced by a
+      top-level dynamic method/field/export analyzer) are folded into a synthesized
+      holder-class entry keyed by the parent obfuscated class's readable form, so
+      the format contract stays "one MatchedClass per top-level key" (decision #10).
+      Nested children of a class analyzer carry the same Match* types but are
+      identified by their dotted analyzer name (e.g. `Foo.methods.bar`) — those
+      are skipped here because they're already attached to their parent MatchedClass
+      via the parent's `matched_methods` / `matched_fields` / `exports` lists.
     - If two analyzers produce MatchedClass entries with the same captured
       `original.name`, raise DuplicateCapturedNameError (decision #9).
     """
@@ -315,12 +319,17 @@ def flatten_analyzer_results(
     # Holder classes synthesized for top-level dynamic method/field/export results
     # are tracked separately so we can attach multiple top-level analyzers' results
     # to the same obfuscated class without re-triggering the duplicate-name check.
-    holders_by_smali_java: dict[str, MatchedClass] = {}
+    holders_by_smali_java: dict[tuple[str, str], MatchedClass] = {}
 
     for analyzer_name, entries in analyzer_results.items():
         for entry in entries:
             if isinstance(entry, MatchedClass):
                 _add_matched_class(entry, analyzer_name, by_captured_name, captured_name_origin)
+            elif _is_child_analyzer_name(analyzer_name):
+                # Nested child results are already attached to their parent MatchedClass
+                # (see ChildAnalyzer._update_parent_with_child_result). Skipping them here
+                # avoids duplicating them into a synthesized holder class.
+                continue
             else:
                 _attach_to_holder(entry, holders_by_smali_java)
 
@@ -363,16 +372,31 @@ def _add_matched_class(
     captured_name_origin[captured] = analyzer_name
 
 
-def _attach_to_holder(entry: Result, holders_by_smali_java: dict[str, MatchedClass]) -> None:
+def _is_child_analyzer_name(analyzer_name: str) -> bool:
+    """Return True for dotted child analyzer names (e.g. `Class.methods.foo`).
+
+    The orchestrator uses dotted names exclusively for `ChildAnalyzer` instances
+    (see `FieldAnalyzer.name`, `MethodAnalyzer.name`, `ExportAnalyzer.name`).
+    Top-level analyzers — including top-level dynamic method/field/export — use
+    the raw definition name, which never contains the axis infixes.
+    """
+    return ".methods." in analyzer_name or ".fields." in analyzer_name or ".exports." in analyzer_name
+
+
+def _attach_to_holder(entry: Result, holders_by_smali_java: dict[tuple[str, str], MatchedClass]) -> None:
     smali_class = getattr(entry, "smali_class", None)
     if smali_class is None:
         # Defensive: a non-MatchedClass top-level result without a smali_class has
         # nowhere to land. Skip rather than synthesize a "unknown" holder.
         return
-    smali_java = smali_class.to_java_representation()  # pyright: ignore[reportAny]
-    holder = holders_by_smali_java.get(smali_java)
+    assert isinstance(smali_class, Class)
+    # Key by (java repr, readable name) so a single smali file that yields multiple
+    # readable names (e.g. a dynamic class def capturing two different names from one
+    # file) ends up with one holder per distinct readable name rather than the
+    # second overwriting the first.
+    holder_key = (smali_class.to_java_representation(), smali_class.name)
+    holder = holders_by_smali_java.get(holder_key)
     if holder is None:
-        assert isinstance(smali_class, Class)
         holder = MatchedClass(
             original=smali_class,
             new=smali_class,
@@ -380,7 +404,7 @@ def _attach_to_holder(entry: Result, holders_by_smali_java: dict[str, MatchedCla
             matched_fields=[],
             exports=[],
         )
-        holders_by_smali_java[smali_java] = holder
+        holders_by_smali_java[holder_key] = holder
     if isinstance(entry, MatchedMethod):
         holder.matched_methods.append(entry)
     elif isinstance(entry, MatchedField):

--- a/src/sigmatcher/results.py
+++ b/src/sigmatcher/results.py
@@ -17,10 +17,14 @@ class Export(pydantic.BaseModel, frozen=True):
 
 class MatchedExport(pydantic.BaseModel, frozen=True):
     new: Export
+    smali_class: "Class | None" = None
+    """For top-level dynamic export definitions, the obfuscated class the export was
+    found in. Used when emitting output formats so the export gets attached to a
+    synthesized holder class entry. None for static / class-scoped exports."""
 
     @classmethod
-    def from_value(cls, name: str, value: str) -> "MatchedExport":
-        return cls(new=Export(name=name, value=value))
+    def from_value(cls, name: str, value: str, smali_class: "Class | None" = None) -> "MatchedExport":
+        return cls(new=Export(name=name, value=value), smali_class=smali_class)
 
 
 class Field(pydantic.BaseModel, frozen=True):
@@ -43,6 +47,9 @@ class Field(pydantic.BaseModel, frozen=True):
 class MatchedField(pydantic.BaseModel, frozen=True):
     original: Field
     new: Field
+    smali_class: "Class | None" = None
+    """For top-level dynamic field definitions, the obfuscated class the field was
+    found in. Used when emitting output formats. None for static / class-scoped fields."""
 
 
 class Method(pydantic.BaseModel, frozen=True):
@@ -67,6 +74,9 @@ class Method(pydantic.BaseModel, frozen=True):
 class MatchedMethod(pydantic.BaseModel, frozen=True):
     original: Method
     new: Method
+    smali_class: "Class | None" = None
+    """For top-level dynamic method definitions, the obfuscated class the method was
+    found in. Used when emitting output formats. None for static / class-scoped methods."""
 
 
 class Class(pydantic.BaseModel, frozen=True):
@@ -110,5 +120,9 @@ class MatchedClass(pydantic.BaseModel):
     def __hash__(self) -> int:
         return hash((self.original, self.new))
 
+
+MatchedExport.model_rebuild()
+MatchedField.model_rebuild()
+MatchedMethod.model_rebuild()
 
 Result: TypeAlias = MatchedClass | MatchedField | MatchedMethod | MatchedExport

--- a/src/sigmatcher/results.py
+++ b/src/sigmatcher/results.py
@@ -21,10 +21,26 @@ class MatchedExport(pydantic.BaseModel, frozen=True):
     """For top-level dynamic export definitions, the obfuscated class the export was
     found in. Used when emitting output formats so the export gets attached to a
     synthesized holder class entry. None for static / class-scoped exports."""
+    parent_original_name: str | None = None
+    """For nested class-scoped exports under a dynamic parent class definition, the
+    parent MatchedClass's readable `original.name`. Persisted in the cache so the
+    cache-replay path can re-link this export to the correct parent when multiple
+    parents share one smali file but carry different captured names. None for
+    static-parent or top-level exports — they don't need disambiguation."""
 
     @classmethod
-    def from_value(cls, name: str, value: str, smali_class: "Class | None" = None) -> "MatchedExport":
-        return cls(new=Export(name=name, value=value), smali_class=smali_class)
+    def from_value(
+        cls,
+        name: str,
+        value: str,
+        smali_class: "Class | None" = None,
+        parent_original_name: str | None = None,
+    ) -> "MatchedExport":
+        return cls(
+            new=Export(name=name, value=value),
+            smali_class=smali_class,
+            parent_original_name=parent_original_name,
+        )
 
 
 class Field(pydantic.BaseModel, frozen=True):
@@ -50,6 +66,10 @@ class MatchedField(pydantic.BaseModel, frozen=True):
     smali_class: "Class | None" = None
     """For top-level dynamic field definitions, the obfuscated class the field was
     found in. Used when emitting output formats. None for static / class-scoped fields."""
+    parent_original_name: str | None = None
+    """For nested class-scoped fields under a dynamic parent class definition, the
+    parent MatchedClass's readable `original.name`. See `MatchedExport.parent_original_name`
+    for the full rationale."""
 
 
 class Method(pydantic.BaseModel, frozen=True):
@@ -77,6 +97,10 @@ class MatchedMethod(pydantic.BaseModel, frozen=True):
     smali_class: "Class | None" = None
     """For top-level dynamic method definitions, the obfuscated class the method was
     found in. Used when emitting output formats. None for static / class-scoped methods."""
+    parent_original_name: str | None = None
+    """For nested class-scoped methods under a dynamic parent class definition, the
+    parent MatchedClass's readable `original.name`. See `MatchedExport.parent_original_name`
+    for the full rationale."""
 
 
 class Class(pydantic.BaseModel, frozen=True):

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -1102,3 +1102,82 @@ def test_cache_round_trip_one_smali_two_captured_names(tmp_path: Path, monkeypat
     assert isinstance(second_parents, list)
     second_captured = {p.original.name for p in second_parents if isinstance(p, MatchedClass)}
     assert second_captured == {"Alpha", "Beta"}
+
+
+@pytest.mark.integration
+def test_cache_replay_relinks_children_for_multi_capture_one_smali(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dynamic parent def whose regex captures TWO readable names from ONE smali file
+    has BOTH parents share a single obfuscated java repr. On cache replay, each parent
+    MatchedClass must still have its nested static child correctly attached — the
+    cache-replay path needs `parent_original_name` to disambiguate which parent gets
+    the cached child.
+
+    Regression test for F1 of the dynamic-redesign CR. Pre-fix, keying parents by smali
+    java repr alone made `_parent_for_cached` return None for an ambiguous pair, the
+    nested child was silently dropped from `MatchedClass.matched_fields` on the second
+    run, and BLOCKER 1's flatten filter then dropped it from output formats too."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    # Single smali file with two distinct readable names captured by the parent regex.
+    # The static child field `value:I` is defined exactly once in this file, so both
+    # captured parents are expected to receive the same MatchedField — but each parent
+    # MatchedClass keeps its own independent matched_fields list.
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public describe()Ljava/lang/String;\n"
+        '    const-string v0, "Alpha{state=on"\n'
+        '    const-string v1, "Beta{state=off"\n'
+        "    return-object v0\n"
+        ".end method\n"
+        ".field private final value:I\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="DynParent",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+            fields=(
+                FieldDefinition(
+                    name="value",
+                    signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<match>value:I)")),),
+                ),
+            ),
+        ),
+    ]
+
+    first = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    first_parents = first["DynParent"]
+    assert isinstance(first_parents, list)
+    first_by_name = {p.original.name: p for p in first_parents if isinstance(p, MatchedClass)}
+    assert set(first_by_name) == {"Alpha", "Beta"}
+    # Sanity: both parents got the static child on the first run.
+    assert [f.original.name for f in first_by_name["Alpha"].matched_fields] == ["value"]
+    assert [f.original.name for f in first_by_name["Beta"].matched_fields] == ["value"]
+
+    # On cache replay both parents must STILL carry the child. Pre-fix, one of the two
+    # parents would have an empty matched_fields list because the parent-by-smali dict
+    # collapsed both readable names down to a single java-repr key.
+    cache_path = cache.get_results_cache_path()
+    assert cache_path.exists(), "first analyze() must have written the results cache"
+    second = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    second_parents = second["DynParent"]
+    assert isinstance(second_parents, list)
+    second_by_name = {p.original.name: p for p in second_parents if isinstance(p, MatchedClass)}
+    assert set(second_by_name) == {"Alpha", "Beta"}
+    assert [f.original.name for f in second_by_name["Alpha"].matched_fields] == ["value"]
+    assert [f.original.name for f in second_by_name["Beta"].matched_fields] == ["value"]
+
+    # And the cached child results themselves must still list both parents.
+    second_children = second["DynParent.fields.value"]
+    assert isinstance(second_children, list)
+    parent_names = {c.parent_original_name for c in second_children if isinstance(c, MatchedField)}
+    assert parent_names == {"Alpha", "Beta"}

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -6,8 +6,18 @@ import pytest
 import sigmatcher.definitions
 from sigmatcher.analysis import analyze
 from sigmatcher.cache import Cache
-from sigmatcher.definitions import ClassDefinition, ExportDefinition, FieldDefinition, MethodDefinition, RegexSignature
-from sigmatcher.errors import MacroPointsToDynamicError, MissingDynamicCaptureGroupError
+from sigmatcher.definitions import (
+    ClassDefinition,
+    ExportDefinition,
+    FieldDefinition,
+    MethodDefinition,
+    RegexSignature,
+    TopLevelDefinition,
+    TopLevelExportDefinition,
+    TopLevelFieldDefinition,
+    TopLevelMethodDefinition,
+)
+from sigmatcher.errors import MacroPointsToDynamicError, MissingDynamicCaptureGroupError, SigmatcherError
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -445,3 +455,440 @@ def test_macro_points_at_dynamic_def_load_error() -> None:
         validate_definitions(definitions)
     assert exc_info.value.analyzer_name == "NetworkHandler"
     assert exc_info.value.dynamic_dependency == "UnknownToStringClass"
+
+
+def _setup_corpus(tmp_path: Path) -> tuple[Cache, Path]:
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+    return cache, apktool_dir
+
+
+EXPECTED_TWO_PARENT_MATCHES = 2
+
+
+@pytest.mark.integration
+def test_top_level_dynamic_class_def_multi_match(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single dynamic class def that matches three smali files produces three results."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    for obfuscated, readable in (("a", "Alpha"), ("b", "Beta"), ("c", "Gamma")):
+        _write_dynamic_name_smali(
+            apktool_dir,
+            obfuscated,
+            ".method public toString()Ljava/lang/String;\n"
+            f'    const-string v0, "{readable}{{state=on"\n'
+            "    return-object v0\n"
+            ".end method\n",
+        )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="ToStringPlaceholder",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    matches = results["ToStringPlaceholder"]
+    assert isinstance(matches, list)
+    captured = {m.original.name for m in matches if isinstance(m, MatchedClass)}
+    assert captured == {"Alpha", "Beta", "Gamma"}
+
+
+@pytest.mark.integration
+def test_top_level_dynamic_method_def_corpus_scan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    for obfuscated in ("a", "b"):
+        _write_dynamic_name_smali(
+            apktool_dir,
+            obfuscated,
+            ".method public toString()Ljava/lang/String;\n"
+            "    .registers 2\n"
+            f'    const-string v0, "{obfuscated.upper()}_TOKEN"\n'
+            "    return-object v0\n"
+            ".end method\n",
+        )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelMethodDefinition(
+            name="AutoToStringPlaceholder",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'const-string v\d+, "(?P<method_name>\w+_TOKEN)"', "count": "1-10"}
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    matches = results["AutoToStringPlaceholder"]
+    assert isinstance(matches, list)
+    captured = {m.original.name for m in matches if isinstance(m, MatchedMethod)}
+    assert captured == {"A_TOKEN", "B_TOKEN"}
+
+
+@pytest.mark.integration
+def test_top_level_dynamic_field_def_corpus_scan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".field private final socket:Lcom/example/Socket;\n.field private final buffer:Lcom/example/Buffer;\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelFieldDefinition(
+            name="ExampleFieldPlaceholder",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r"\.field private final (?P<match>(?P<field_name>\w+):Lcom/example/\w+;)",
+                        "count": "1-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    matches = results["ExampleFieldPlaceholder"]
+    assert isinstance(matches, list)
+    captured = {m.original.name for m in matches if isinstance(m, MatchedField)}
+    assert captured == {"socket", "buffer"}
+
+
+@pytest.mark.integration
+def test_top_level_dynamic_export_def_corpus_scan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        '    const-string v0, "FEATURE_alpha"\n    const-string v1, "FEATURE_beta"\n',
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelExportDefinition(
+            name="FeatureFlag",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<match>FEATURE_(?P<export_name>\w+))"', "count": "1-10"}
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    matches = results["FeatureFlag"]
+    assert isinstance(matches, list)
+    captured = {m.new.name for m in matches if isinstance(m, MatchedExport)}
+    assert captured == {"alpha", "beta"}
+
+
+@pytest.mark.integration
+def test_dynamic_def_zero_matches_is_not_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dynamic def that matches nothing yields an empty list, not an exception (decision #8)."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(apktool_dir, "a", "")
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelMethodDefinition(
+            name="WontMatchAnything",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<method_name>nothing-here)"', "count": "0-10"}
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    assert results["WontMatchAnything"] == []
+
+
+@pytest.mark.integration
+def test_dynamic_parent_with_static_children_all_or_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dynamic parent matching N classes: a static child that fails for one of them
+    yields one SigmatcherError for the whole child (decision #6). When all parents
+    yield the child cleanly, the child produces N results."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    # Two classes match the dynamic parent. The child field signature only matches
+    # in one of them — so the all-or-nothing rule should surface a single error.
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "Alpha{state=on"\n'
+        "    return-object v0\n"
+        ".end method\n"
+        ".field private final value:I\n",
+    )
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "b",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "Beta{state=on"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="DynParent",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+            fields=(
+                FieldDefinition(
+                    name="value",
+                    signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<match>value:I)")),),
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    parent_matches = results["DynParent"]
+    assert isinstance(parent_matches, list)
+    assert len(parent_matches) == EXPECTED_TWO_PARENT_MATCHES
+
+    child_result = results["DynParent.fields.value"]
+    # The static child cannot match in the Beta parent, so per decision #6 the entire
+    # child result is one SigmatcherError, not a mixed list.
+    assert isinstance(child_result, SigmatcherError)
+
+
+@pytest.mark.integration
+def test_dynamic_parent_with_static_children_success_yields_n_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Companion to the all-or-nothing test: when the static child succeeds for every
+    parent match, the child analyzer produces N results."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    for obfuscated, readable in (("a", "Alpha"), ("b", "Beta")):
+        _write_dynamic_name_smali(
+            apktool_dir,
+            obfuscated,
+            ".method public toString()Ljava/lang/String;\n"
+            f'    const-string v0, "{readable}{{state=on"\n'
+            "    return-object v0\n"
+            ".end method\n"
+            ".field private final value:I\n",
+        )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="DynParent",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+            fields=(
+                FieldDefinition(
+                    name="value",
+                    signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<match>value:I)")),),
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    child_result = results["DynParent.fields.value"]
+    assert isinstance(child_result, list)
+    assert len(child_result) == EXPECTED_TWO_PARENT_MATCHES
+
+
+@pytest.mark.integration
+def test_static_parent_dynamic_method_child(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A top-level dynamic method def works alongside a static class def in the same
+    signature file. Covers the 0, 1, and N capture cases for the top-level method
+    analyzer (the static class def is just a co-tenant)."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "Alpha"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "b",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "Beta"\n'
+        "    return-object v0\n"
+        ".end method\n"
+        ".method public toString2()Ljava/lang/String;\n"
+        '    const-string v0, "BetaTwo"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "c",
+        ".method public irrelevant()V\n    return-void\n.end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelMethodDefinition(
+            name="ToStringMethods",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'const-string v\d+, "(?P<method_name>\w+)"',
+                        "count": "1-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    matches = results["ToStringMethods"]
+    assert isinstance(matches, list)
+    captured = {m.original.name for m in matches if isinstance(m, MatchedMethod)}
+    # 3 method captures expected: Alpha (a), Beta (b), BetaTwo (b). c.smali has no
+    # const-string so it contributes nothing — exercising the 0-capture-per-file path.
+    assert captured == {"Alpha", "Beta", "BetaTwo"}
+
+
+@pytest.mark.integration
+def test_dynamic_parent_with_dynamic_children(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both axes dynamic: dynamic parent matching N classes paired with a top-level
+    dynamic method analyzer should yield N method results across the matched parents."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    for obfuscated, readable in (("a", "Alpha"), ("b", "Beta")):
+        _write_dynamic_name_smali(
+            apktool_dir,
+            obfuscated,
+            ".method public toString()Ljava/lang/String;\n"
+            f'    const-string v0, "{readable}{{state=on"\n'
+            "    return-object v0\n"
+            ".end method\n",
+        )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="DynParent",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+        ),
+        TopLevelMethodDefinition(
+            name="DynToStringChild",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'const-string v\d+, "(?P<method_name>\w+)\{state=',
+                        "count": "1-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    parent_matches = results["DynParent"]
+    assert isinstance(parent_matches, list)
+    method_matches = results["DynToStringChild"]
+    assert isinstance(method_matches, list)
+    captured_methods = {m.original.name for m in method_matches if isinstance(m, MatchedMethod)}
+    assert captured_methods == {"Alpha", "Beta"}
+
+
+@pytest.mark.integration
+def test_cache_round_trip_dynamic_multi_match(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Write the cache, re-run, verify N matches are restored and child re-linking works."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    for obfuscated, readable in (("a", "Alpha"), ("b", "Beta")):
+        _write_dynamic_name_smali(
+            apktool_dir,
+            obfuscated,
+            ".method public toString()Ljava/lang/String;\n"
+            f'    const-string v0, "{readable}{{state=on"\n'
+            "    return-object v0\n"
+            ".end method\n"
+            ".field private final value:I\n",
+        )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="DynParent",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+            fields=(
+                FieldDefinition(
+                    name="value",
+                    signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<match>value:I)")),),
+                ),
+            ),
+        ),
+    ]
+
+    first = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    assert isinstance(first["DynParent"], list)
+    assert len(first["DynParent"]) == EXPECTED_TWO_PARENT_MATCHES
+
+    second = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    parent_matches = second["DynParent"]
+    assert isinstance(parent_matches, list)
+    assert len(parent_matches) == EXPECTED_TWO_PARENT_MATCHES
+    captured = {m.original.name for m in parent_matches if isinstance(m, MatchedClass)}
+    assert captured == {"Alpha", "Beta"}
+
+    child_results = second["DynParent.fields.value"]
+    assert isinstance(child_results, list)
+    assert len(child_results) == EXPECTED_TWO_PARENT_MATCHES
+    # Each child carries its parent's obfuscated java repr so re-linking is unambiguous.
+    parent_javas: set[str] = set()
+    for child in child_results:
+        assert isinstance(child, MatchedField)
+        assert child.smali_class is not None
+        parent_javas.add(child.smali_class.to_java_representation())
+    assert parent_javas == {"Lcom/example/a;", "Lcom/example/b;"}

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -17,7 +17,11 @@ from sigmatcher.definitions import (
     TopLevelFieldDefinition,
     TopLevelMethodDefinition,
 )
-from sigmatcher.errors import MacroPointsToDynamicError, MissingDynamicCaptureGroupError, SigmatcherError
+from sigmatcher.errors import (
+    ChildFailedForParentError,
+    MacroPointsToDynamicError,
+    MissingDynamicCaptureGroupError,
+)
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -783,7 +787,19 @@ def test_dynamic_parent_with_static_children_all_or_nothing(tmp_path: Path, monk
     child_result = results["DynParent.fields.value"]
     # The static child cannot match in the Beta parent, so per decision #6 the entire
     # child result is one SigmatcherError, not a mixed list.
-    assert isinstance(child_result, SigmatcherError)
+    assert isinstance(child_result, ChildFailedForParentError)
+    # The error must name the *failing* parent class so authors can disambiguate
+    # which capture caused the failure. Beta is the parent without a `value:I` field.
+    assert child_result.parent_class_java == "Lcom/example/b;"
+    debug = child_result.debug_message()
+    short = child_result.short_message()
+    assert "Lcom/example/b;" in debug or "Lcom/example/b;" in short
+    # All-or-nothing: the successful per-parent capture for Alpha must be DISCARDED
+    # — the parent MatchedClass must not retain a MatchedField from this run.
+    alpha_parent = next(
+        match for match in parent_matches if isinstance(match, MatchedClass) and match.original.name == "Alpha"
+    )
+    assert alpha_parent.matched_fields == []
 
 
 @pytest.mark.integration

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -379,3 +379,69 @@ def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
     result = results["UnknownToStringClass"]
     assert isinstance(result, MissingClassNameGroupError)
     assert result.app_version == "1.0.0"
+
+
+@pytest.mark.integration
+def test_analyze_dynamic_name_macro_reference_from_other_definition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second ClassDefinition references the dynamic-name class via ${X.java}.
+    The macro should resolve to the obfuscated class (not the captured readable name),
+    the dependent class should match, and the captured readable name should propagate
+    to the dynamic-name class result."""
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "ConnectionManager{state=connected"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+    network_handler_smali = apktool_dir / "NetworkHandler.smali"
+    _ = network_handler_smali.write_text(
+        ".class public Lcom/example/n;\n"
+        ".super Ljava/lang/Object;\n"
+        ".method public handle()V\n"
+        "    new-instance v0, Lcom/example/a;\n"
+        "    return-void\n"
+        ".end method\n"
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r'"(?P<class_name>\w+)\{state='),
+                ),
+            ),
+        ),
+        ClassDefinition(
+            name="NetworkHandler",
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r"new-instance v\d+, ${UnknownToStringClass.java}"),
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+
+    dynamic_result = results["UnknownToStringClass"]
+    assert isinstance(dynamic_result, MatchedClass)
+    assert dynamic_result.original.name == "ConnectionManager"
+    assert dynamic_result.new.to_java_representation() == "Lcom/example/a;"
+
+    network_result = results["NetworkHandler"]
+    assert isinstance(network_result, MatchedClass)
+    assert network_result.new.to_java_representation() == "Lcom/example/n;"

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -1012,3 +1012,49 @@ def test_cache_round_trip_dynamic_multi_match(tmp_path: Path, monkeypatch: pytes
         assert child.smali_class is not None
         parent_javas.add(child.smali_class.to_java_representation())
     assert parent_javas == {"Lcom/example/a;", "Lcom/example/b;"}
+
+
+@pytest.mark.integration
+def test_cache_round_trip_one_smali_two_captured_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single dynamic parent def whose signature matches one smali file but captures
+    two distinct readable names (Alpha and Beta) must surface BOTH parents independently
+    on cache replay. Pre-fix, the parent-by-smali dict was keyed by java repr only, so
+    the second readable name overwrote the first."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public describe()Ljava/lang/String;\n"
+        '    const-string v0, "Alpha{state=on"\n'
+        '    const-string v1, "Beta{state=off"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="DynParent",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {"type": "regex", "signature": r'"(?P<class_name>\w+)\{state=', "count": "1-10"}
+                ),
+            ),
+        ),
+    ]
+
+    first = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    first_parents = first["DynParent"]
+    assert isinstance(first_parents, list)
+    first_captured = {p.original.name for p in first_parents if isinstance(p, MatchedClass)}
+    assert first_captured == {"Alpha", "Beta"}
+
+    # Cache replay: both captured-name parents must survive independently — neither
+    # one should overwrite the other in the cache-rebuild path.
+    second = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    second_parents = second["DynParent"]
+    assert isinstance(second_parents, list)
+    second_captured = {p.original.name for p in second_parents if isinstance(p, MatchedClass)}
+    assert second_captured == {"Alpha", "Beta"}

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -425,6 +425,50 @@ def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
     assert result.app_version == "1.0.0"
 
 
+@pytest.mark.integration
+def test_programmatic_analyze_calls_validate_definitions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Programmatic callers using sigmatcher.analysis.analyze directly must not be able
+    to bypass the dynamic-macro validator. Pre-fix, the CLI's _read_definitions wrapper
+    was the only validation gate; calling analyze() with a macro-to-dynamic definition
+    set would slip past validation and crash with a bare AssertionError downstream."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "ConnectionManager{state=connected"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r'"(?P<class_name>\w+)\{state='),
+                ),
+            ),
+        ),
+        ClassDefinition(
+            name="NetworkHandler",
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r"new-instance v\d+, ${UnknownToStringClass.java}"),
+                ),
+            ),
+        ),
+    ]
+
+    with pytest.raises(MacroPointsToDynamicError):
+        _ = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+
+
 def test_macro_points_at_dynamic_def_load_error() -> None:
     """A second ClassDefinition references a dynamic-name class via ${X.java}.
 

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -94,23 +94,36 @@ def test_analyze_end_to_end_with_macros_and_children(tmp_path: Path, monkeypatch
 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
 
-    assert isinstance(results["ConnectionManager"], MatchedClass)
-    assert isinstance(results["ConnectionManager.methods.read"], MatchedMethod)
-    assert isinstance(results["ConnectionManager.fields.counter"], MatchedField)
-    assert isinstance(results["ConnectionManager.exports.readConst"], MatchedExport)
-    assert isinstance(results["NetworkHandler"], MatchedClass)
-
-    connection_manager_result = results["ConnectionManager"]
+    connection_manager_results = results["ConnectionManager"]
+    assert isinstance(connection_manager_results, list)
+    assert len(connection_manager_results) == 1
+    connection_manager_result = connection_manager_results[0]
     assert isinstance(connection_manager_result, MatchedClass)
     assert connection_manager_result.new.to_java_representation() == "Lcom/example/a;"
 
-    network_handler_result = results["NetworkHandler"]
+    read_results = results["ConnectionManager.methods.read"]
+    assert isinstance(read_results, list)
+    assert isinstance(read_results[0], MatchedMethod)
+
+    counter_results = results["ConnectionManager.fields.counter"]
+    assert isinstance(counter_results, list)
+    assert isinstance(counter_results[0], MatchedField)
+
+    export_results = results["ConnectionManager.exports.readConst"]
+    assert isinstance(export_results, list)
+    assert isinstance(export_results[0], MatchedExport)
+
+    network_handler_results = results["NetworkHandler"]
+    assert isinstance(network_handler_results, list)
+    network_handler_result = network_handler_results[0]
     assert isinstance(network_handler_result, MatchedClass)
     assert network_handler_result.new.to_java_representation() == "Lcom/example/n;"
 
     cached_results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
 
-    cached_connection_manager_result = cached_results["ConnectionManager"]
+    cached_connection_manager_results = cached_results["ConnectionManager"]
+    assert isinstance(cached_connection_manager_results, list)
+    cached_connection_manager_result = cached_connection_manager_results[0]
     assert isinstance(cached_connection_manager_result, MatchedClass)
     assert [method.original.name for method in cached_connection_manager_result.matched_methods] == ["read"]
     assert [field.original.name for field in cached_connection_manager_result.matched_fields] == ["counter"]
@@ -156,7 +169,10 @@ def test_analyze_dynamic_name_captures_readable_name(tmp_path: Path, monkeypatch
 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
 
-    result = results["UnknownToStringClass"]
+    result_entries = results["UnknownToStringClass"]
+    assert isinstance(result_entries, list)
+    assert len(result_entries) == 1
+    result = result_entries[0]
     assert isinstance(result, MatchedClass)
     assert result.original.name == "ConnectionManager"
     assert result.new.to_java_representation() == "Lcom/example/a;"
@@ -272,12 +288,16 @@ def test_analyze_dynamic_name_cache_round_trip(tmp_path: Path, monkeypatch: pyte
     ]
 
     first = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
-    first_result = first["UnknownToStringClass"]
+    first_entries = first["UnknownToStringClass"]
+    assert isinstance(first_entries, list)
+    first_result = first_entries[0]
     assert isinstance(first_result, MatchedClass)
     assert first_result.original.name == "ConnectionManager"
 
     cached = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
-    cached_result = cached["UnknownToStringClass"]
+    cached_entries = cached["UnknownToStringClass"]
+    assert isinstance(cached_entries, list)
+    cached_result = cached_entries[0]
     assert isinstance(cached_result, MatchedClass)
     assert cached_result.original.name == "ConnectionManager"
     assert cached_result.new.to_java_representation() == "Lcom/example/a;"
@@ -323,7 +343,10 @@ def test_analyze_dynamic_name_strips_whitespace_and_collapses_captures(
     ]
 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
-    result = results["UnknownToStringClass"]
+    result_entries = results["UnknownToStringClass"]
+    assert isinstance(result_entries, list)
+    assert len(result_entries) == 1
+    result = result_entries[0]
     assert isinstance(result, MatchedClass)
     assert result.original.name == "ConnectionManager"
 
@@ -437,11 +460,15 @@ def test_analyze_dynamic_name_macro_reference_from_other_definition(
 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
 
-    dynamic_result = results["UnknownToStringClass"]
+    dynamic_entries = results["UnknownToStringClass"]
+    assert isinstance(dynamic_entries, list)
+    dynamic_result = dynamic_entries[0]
     assert isinstance(dynamic_result, MatchedClass)
     assert dynamic_result.original.name == "ConnectionManager"
     assert dynamic_result.new.to_java_representation() == "Lcom/example/a;"
 
-    network_result = results["NetworkHandler"]
+    network_entries = results["NetworkHandler"]
+    assert isinstance(network_entries, list)
+    network_result = network_entries[0]
     assert isinstance(network_result, MatchedClass)
     assert network_result.new.to_java_representation() == "Lcom/example/n;"

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -7,7 +7,7 @@ import sigmatcher.definitions
 from sigmatcher.analysis import analyze
 from sigmatcher.cache import Cache
 from sigmatcher.definitions import ClassDefinition, ExportDefinition, FieldDefinition, MethodDefinition, RegexSignature
-from sigmatcher.errors import MissingClassNameGroupError, NoMatchesError, TooManyMatchesError
+from sigmatcher.errors import MissingClassNameGroupError
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -179,9 +179,10 @@ def test_analyze_dynamic_name_captures_readable_name(tmp_path: Path, monkeypatch
 
 
 @pytest.mark.integration
-def test_analyze_dynamic_name_zero_captures_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_analyze_dynamic_name_zero_captures_is_empty_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """File-level signature matches via a non-capturing alternative, but the class_name
-    group never captures anything. Should fail with NoMatchesError."""
+    group never captures anything. With the dynamic 0+ redesign this is a legitimate
+    empty result list — not an error."""
     cache = Cache(tmp_path / "cache")
     apktool_dir = cache.get_apktool_cache_dir()
     apktool_dir.mkdir(parents=True)
@@ -213,11 +214,16 @@ def test_analyze_dynamic_name_zero_captures_raises(tmp_path: Path, monkeypatch: 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
 
     result = results["UnknownToStringClass"]
-    assert isinstance(result, NoMatchesError)
+    assert result == []
 
 
 @pytest.mark.integration
-def test_analyze_dynamic_name_multi_capture_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_analyze_dynamic_name_multi_capture_yields_multiple_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dynamic class definition that captures multiple distinct readable names from
+    the same smali file emits one MatchedClass per captured name (decision #1 of the
+    redesign: dynamic defs match 0+ entities)."""
     cache = Cache(tmp_path / "cache")
     apktool_dir = cache.get_apktool_cache_dir()
     apktool_dir.mkdir(parents=True)
@@ -252,9 +258,10 @@ def test_analyze_dynamic_name_multi_capture_raises(tmp_path: Path, monkeypatch: 
 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
 
-    result = results["UnknownToStringClass"]
-    assert isinstance(result, TooManyMatchesError)
-    assert result.matches == {"Alpha", "Beta"}
+    matches = results["UnknownToStringClass"]
+    assert isinstance(matches, list)
+    captured_names = {match.original.name for match in matches if isinstance(match, MatchedClass)}
+    assert captured_names == {"Alpha", "Beta"}
 
 
 @pytest.mark.integration

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -7,7 +7,7 @@ import sigmatcher.definitions
 from sigmatcher.analysis import analyze
 from sigmatcher.cache import Cache
 from sigmatcher.definitions import ClassDefinition, ExportDefinition, FieldDefinition, MethodDefinition, RegexSignature
-from sigmatcher.errors import NoMatchesError, TooManyMatchesError
+from sigmatcher.errors import MissingClassNameGroupError, NoMatchesError, TooManyMatchesError
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -271,3 +271,56 @@ def test_analyze_dynamic_name_cache_round_trip(tmp_path: Path, monkeypatch: pyte
     assert isinstance(cached_result, MatchedClass)
     assert cached_result.original.name == "ConnectionManager"
     assert cached_result.new.to_java_representation() == "Lcom/example/a;"
+
+
+@pytest.mark.integration
+def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A definition with two signatures — one non-capturing for old versions, one
+    capturing for new versions — passes model-level validation but the runtime
+    subset for an old version has no class_name group. The analyzer raises the
+    dedicated MissingClassNameGroupError instead of a misleading NoMatchesError."""
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "legacy-token"\n'
+        '    const-string v1, "ConnectionManager{state=connected"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r"legacy-token",
+                        "version_range": "<2.0.0",
+                    }
+                ),
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'"(?P<class_name>\w+)\{state=',
+                        "version_range": ">=2.0.0",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    result = results["UnknownToStringClass"]
+    assert isinstance(result, MissingClassNameGroupError)
+    assert result.app_version == "1.0.0"

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -7,7 +7,7 @@ import sigmatcher.definitions
 from sigmatcher.analysis import analyze
 from sigmatcher.cache import Cache
 from sigmatcher.definitions import ClassDefinition, ExportDefinition, FieldDefinition, MethodDefinition, RegexSignature
-from sigmatcher.errors import MacroPointsToDynamicError, MissingClassNameGroupError
+from sigmatcher.errors import MacroPointsToDynamicError, MissingDynamicCaptureGroupError
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -365,7 +365,7 @@ def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
     """A definition with two signatures — one non-capturing for old versions, one
     capturing for new versions — passes model-level validation but the runtime
     subset for an old version has no class_name group. The analyzer raises the
-    dedicated MissingClassNameGroupError instead of a misleading NoMatchesError."""
+    dedicated MissingDynamicCaptureGroupError instead of a misleading NoMatchesError."""
     cache = Cache(tmp_path / "cache")
     apktool_dir = cache.get_apktool_cache_dir()
     apktool_dir.mkdir(parents=True)
@@ -407,7 +407,7 @@ def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
 
     results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
     result = results["UnknownToStringClass"]
-    assert isinstance(result, MissingClassNameGroupError)
+    assert isinstance(result, MissingDynamicCaptureGroupError)
     assert result.app_version == "1.0.0"
 
 

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -602,6 +602,110 @@ def test_top_level_dynamic_export_def_corpus_scan(tmp_path: Path, monkeypatch: p
 
 
 @pytest.mark.integration
+def test_top_level_dynamic_method_non_participating_capture_group_yields_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the BLOCKER-2 fix: a method_name group inside an alternation that the actual
+    input matches via the non-capturing alternative must not crash with AttributeError."""
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "sentinel"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelMethodDefinition(
+            name="TolerantMethod",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'const-string v\d+, "(?:sentinel|(?P<method_name>FOO))"',
+                        "count": "0-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    assert results["TolerantMethod"] == []
+
+
+@pytest.mark.integration
+def test_top_level_dynamic_field_non_participating_capture_group_yields_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".field private final sentinel:I\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelFieldDefinition(
+            name="TolerantField",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r"\.field private final (?:sentinel|(?P<field_name>foo)):I",
+                        "count": "0-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    assert results["TolerantField"] == []
+
+
+@pytest.mark.integration
+def test_top_level_dynamic_export_non_participating_capture_group_yields_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache, apktool_dir = _setup_corpus(tmp_path)
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        '    const-string v0, "SENTINEL_TOKEN"\n',
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions: list[TopLevelDefinition] = [
+        TopLevelExportDefinition(
+            name="TolerantExport",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'"(?P<match>SENTINEL_TOKEN|(?P<export_name>FEATURE_\w+))"',
+                        "count": "0-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    assert results["TolerantExport"] == []
+
+
+@pytest.mark.integration
 def test_dynamic_def_zero_matches_is_not_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A dynamic def that matches nothing yields an empty list, not an exception (decision #8)."""
     cache, apktool_dir = _setup_corpus(tmp_path)

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -173,7 +173,10 @@ def test_analyze_dynamic_name_zero_captures_raises(tmp_path: Path, monkeypatch: 
     _write_dynamic_name_smali(
         apktool_dir,
         "a",
-        '    const-string v0, "trigger-token"\n',
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "trigger-token"\n'
+        "    return-object v0\n"
+        ".end method\n",
     )
 
     monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
@@ -206,7 +209,11 @@ def test_analyze_dynamic_name_multi_capture_raises(tmp_path: Path, monkeypatch: 
     _write_dynamic_name_smali(
         apktool_dir,
         "a",
-        '    const-string v0, "Alpha{state=on"\n    const-string v1, "Beta{state=off"\n',
+        ".method public describe()Ljava/lang/String;\n"
+        '    const-string v0, "Alpha{state=on"\n'
+        '    const-string v1, "Beta{state=off"\n'
+        "    return-object v0\n"
+        ".end method\n",
     )
 
     monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
@@ -243,7 +250,10 @@ def test_analyze_dynamic_name_cache_round_trip(tmp_path: Path, monkeypatch: pyte
     _write_dynamic_name_smali(
         apktool_dir,
         "a",
-        '    const-string v0, "ConnectionManager{state=connected"\n',
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "ConnectionManager{state=connected"\n'
+        "    return-object v0\n"
+        ".end method\n",
     )
 
     monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -274,6 +274,51 @@ def test_analyze_dynamic_name_cache_round_trip(tmp_path: Path, monkeypatch: pyte
 
 
 @pytest.mark.integration
+def test_analyze_dynamic_name_strips_whitespace_and_collapses_captures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the documented semantics: captures are compared after str.strip(), so the
+    same readable name captured with and without leading whitespace collapses to a
+    single value instead of raising TooManyMatchesError."""
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public describe()Ljava/lang/String;\n"
+        '    const-string v0, " ConnectionManager{state=on"\n'
+        '    const-string v1, "ConnectionManager{state=off"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'"(?P<class_name>\s?\w+)\{state=',
+                        "count": "1-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    result = results["UnknownToStringClass"]
+    assert isinstance(result, MatchedClass)
+    assert result.original.name == "ConnectionManager"
+
+
+@pytest.mark.integration
 def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -7,6 +7,7 @@ import sigmatcher.definitions
 from sigmatcher.analysis import analyze
 from sigmatcher.cache import Cache
 from sigmatcher.definitions import ClassDefinition, ExportDefinition, FieldDefinition, MethodDefinition, RegexSignature
+from sigmatcher.errors import NoMatchesError, TooManyMatchesError
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -114,3 +115,159 @@ def test_analyze_end_to_end_with_macros_and_children(tmp_path: Path, monkeypatch
     assert [method.original.name for method in cached_connection_manager_result.matched_methods] == ["read"]
     assert [field.original.name for field in cached_connection_manager_result.matched_fields] == ["counter"]
     assert [export.new.name for export in cached_connection_manager_result.exports] == ["readConst"]
+
+
+def _write_dynamic_name_smali(apktool_dir: Path, obfuscated_name: str, contents: str) -> Path:
+    smali = apktool_dir / f"{obfuscated_name}.smali"
+    header = f".class public Lcom/example/{obfuscated_name};\n.super Ljava/lang/Object;\n"
+    _ = smali.write_text(header + contents)
+    return smali
+
+
+@pytest.mark.integration
+def test_analyze_dynamic_name_captures_readable_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        ".method public toString()Ljava/lang/String;\n"
+        '    const-string v0, "ConnectionManager{state=connected"\n'
+        "    return-object v0\n"
+        ".end method\n",
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r'"(?P<class_name>\w+)\{state='),
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+
+    result = results["UnknownToStringClass"]
+    assert isinstance(result, MatchedClass)
+    assert result.original.name == "ConnectionManager"
+    assert result.new.to_java_representation() == "Lcom/example/a;"
+
+
+@pytest.mark.integration
+def test_analyze_dynamic_name_zero_captures_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """File-level signature matches via a non-capturing alternative, but the class_name
+    group never captures anything. Should fail with NoMatchesError."""
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        '    const-string v0, "trigger-token"\n',
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r'trigger-token|"(?P<class_name>\w+)\{state='),
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+
+    result = results["UnknownToStringClass"]
+    assert isinstance(result, NoMatchesError)
+
+
+@pytest.mark.integration
+def test_analyze_dynamic_name_multi_capture_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        '    const-string v0, "Alpha{state=on"\n    const-string v1, "Beta{state=off"\n',
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature.model_validate(
+                    {
+                        "type": "regex",
+                        "signature": r'"(?P<class_name>\w+)\{state=',
+                        "count": "1-10",
+                    }
+                ),
+            ),
+        ),
+    ]
+
+    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+
+    result = results["UnknownToStringClass"]
+    assert isinstance(result, TooManyMatchesError)
+    assert result.matches == {"Alpha", "Beta"}
+
+
+@pytest.mark.integration
+def test_analyze_dynamic_name_cache_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = Cache(tmp_path / "cache")
+    apktool_dir = cache.get_apktool_cache_dir()
+    apktool_dir.mkdir(parents=True)
+
+    _write_dynamic_name_smali(
+        apktool_dir,
+        "a",
+        '    const-string v0, "ConnectionManager{state=connected"\n',
+    )
+
+    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+
+    definitions = [
+        ClassDefinition(
+            name="UnknownToStringClass",
+            dynamic_name=True,
+            signatures=(
+                RegexSignature(
+                    type="regex",
+                    signature=re.compile(r'"(?P<class_name>\w+)\{state='),
+                ),
+            ),
+        ),
+    ]
+
+    first = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    first_result = first["UnknownToStringClass"]
+    assert isinstance(first_result, MatchedClass)
+    assert first_result.original.name == "ConnectionManager"
+
+    cached = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
+    cached_result = cached["UnknownToStringClass"]
+    assert isinstance(cached_result, MatchedClass)
+    assert cached_result.original.name == "ConnectionManager"
+    assert cached_result.new.to_java_representation() == "Lcom/example/a;"

--- a/tests/integration/test_analyze_flow.py
+++ b/tests/integration/test_analyze_flow.py
@@ -7,7 +7,7 @@ import sigmatcher.definitions
 from sigmatcher.analysis import analyze
 from sigmatcher.cache import Cache
 from sigmatcher.definitions import ClassDefinition, ExportDefinition, FieldDefinition, MethodDefinition, RegexSignature
-from sigmatcher.errors import MissingClassNameGroupError
+from sigmatcher.errors import MacroPointsToDynamicError, MissingClassNameGroupError
 from sigmatcher.results import MatchedClass, MatchedExport, MatchedField, MatchedMethod
 
 
@@ -411,37 +411,13 @@ def test_analyze_dynamic_name_version_filtered_out_raises_dedicated_error(
     assert result.app_version == "1.0.0"
 
 
-@pytest.mark.integration
-def test_analyze_dynamic_name_macro_reference_from_other_definition(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A second ClassDefinition references the dynamic-name class via ${X.java}.
-    The macro should resolve to the obfuscated class (not the captured readable name),
-    the dependent class should match, and the captured readable name should propagate
-    to the dynamic-name class result."""
-    cache = Cache(tmp_path / "cache")
-    apktool_dir = cache.get_apktool_cache_dir()
-    apktool_dir.mkdir(parents=True)
+def test_macro_points_at_dynamic_def_load_error() -> None:
+    """A second ClassDefinition references a dynamic-name class via ${X.java}.
 
-    _write_dynamic_name_smali(
-        apktool_dir,
-        "a",
-        ".method public toString()Ljava/lang/String;\n"
-        '    const-string v0, "ConnectionManager{state=connected"\n'
-        "    return-object v0\n"
-        ".end method\n",
-    )
-    network_handler_smali = apktool_dir / "NetworkHandler.smali"
-    _ = network_handler_smali.write_text(
-        ".class public Lcom/example/n;\n"
-        ".super Ljava/lang/Object;\n"
-        ".method public handle()V\n"
-        "    new-instance v0, Lcom/example/a;\n"
-        "    return-void\n"
-        ".end method\n"
-    )
-
-    monkeypatch.setattr(sigmatcher.definitions, "rip_regex", _python_rip_regex)
+    Dynamic definitions emit 0+ matches and cannot be macro-resolved to a single
+    concrete value (decision #4). The validator that runs after
+    merge_definitions_groups must hard-error at load time, before analysis runs."""
+    from sigmatcher.definitions import validate_definitions  # noqa: PLC0415
 
     definitions = [
         ClassDefinition(
@@ -465,17 +441,7 @@ def test_analyze_dynamic_name_macro_reference_from_other_definition(
         ),
     ]
 
-    results = analyze(definitions=definitions, cache=cache, app_version="1.0.0")
-
-    dynamic_entries = results["UnknownToStringClass"]
-    assert isinstance(dynamic_entries, list)
-    dynamic_result = dynamic_entries[0]
-    assert isinstance(dynamic_result, MatchedClass)
-    assert dynamic_result.original.name == "ConnectionManager"
-    assert dynamic_result.new.to_java_representation() == "Lcom/example/a;"
-
-    network_entries = results["NetworkHandler"]
-    assert isinstance(network_entries, list)
-    network_result = network_entries[0]
-    assert isinstance(network_result, MatchedClass)
-    assert network_result.new.to_java_representation() == "Lcom/example/n;"
+    with pytest.raises(MacroPointsToDynamicError) as exc_info:
+        validate_definitions(definitions)
+    assert exc_info.value.analyzer_name == "NetworkHandler"
+    assert exc_info.value.dynamic_dependency == "UnknownToStringClass"

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 from sigmatcher.analysis import (
+    ResultsMapType,
     create_analyzers,
     filter_signature_matches,
     resolve_macro,
@@ -9,8 +10,8 @@ from sigmatcher.analysis import (
     sort_analyzers,
 )
 from sigmatcher.definitions import ClassDefinition, MacroStatement, MethodDefinition, RegexSignature, Signature
-from sigmatcher.errors import InvalidMacroModifierError, MissingDependenciesError, SigmatcherError
-from sigmatcher.results import Class, MatchedClass, Result
+from sigmatcher.errors import InvalidMacroModifierError, MissingDependenciesError
+from sigmatcher.results import Class, MatchedClass
 
 
 def test_filter_signature_matches_intersects_all_signatures() -> None:
@@ -63,14 +64,16 @@ def test_resolve_macro_invalid_modifier_raises() -> None:
 
 def test_resolve_signatures_substitutes_macros() -> None:
     signatures = (RegexSignature(type="regex", signature=re.compile(r"new-instance v0, ${Target.java}")),)
-    results: dict[str, Result | SigmatcherError] = {
-        "Target": MatchedClass(
-            original=Class(name="OldClass", package="com.old"),
-            new=Class(name="NewClass", package="com.new"),
-            matched_methods=[],
-            matched_fields=[],
-            exports=[],
-        )
+    results: ResultsMapType = {
+        "Target": [
+            MatchedClass(
+                original=Class(name="OldClass", package="com.old"),
+                new=Class(name="NewClass", package="com.new"),
+                matched_methods=[],
+                matched_fields=[],
+                exports=[],
+            )
+        ]
     }
 
     resolved = resolve_signatures(signatures, results, "Analyzer")
@@ -92,7 +95,7 @@ def test_create_and_sort_analyzers_handles_missing_dependencies(tmp_path: Path) 
     assert "Main" in analyzers
     assert "Main.methods.run" in analyzers
 
-    results: dict[str, Result | SigmatcherError] = {}
+    results: ResultsMapType = {}
     order = list(sort_analyzers(analyzers, results))
     assert "Main.methods.run" in order
     assert "Main" in order

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -22,13 +22,13 @@ def test_get_from_apk_and_cache_read_write(tmp_path: Path) -> None:
         matched_fields=[],
         exports=[],
     )
-    payload: ResultsCacheType = {"key": matched}
+    payload: ResultsCacheType = {"key": [matched]}
 
     cache.cache_dir.mkdir(parents=True)
     cache.write_results_cache(payload)
 
     loaded = cache.get_results_cache()
-    assert loaded["key"].new.name == "New"
+    assert loaded["key"][0].new.name == "New"
 
 
 def test_get_from_input_directory_hash_changes_with_apk_content(tmp_path: Path) -> None:

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
+import pytest
+
 from sigmatcher.cli import _read_definitions  # pyright: ignore[reportPrivateUsage]
 from sigmatcher.definitions import ClassDefinition, RegexSignature
+from sigmatcher.errors import DuplicateTopLevelDefinitionError
 
 
 def test_read_definitions_merges_definition_groups(tmp_path: Path) -> None:
@@ -43,3 +46,38 @@ def test_read_definitions_merges_definition_groups(tmp_path: Path) -> None:
     assert isinstance(signature, RegexSignature)
     assert signature.signature.pattern == "new-class-signature"
     assert {method.name for method in class_def.methods} == {"read", "write"}
+
+
+def test_read_definitions_rejects_duplicate_top_level_method(tmp_path: Path) -> None:
+    """Top-level method/field/export defs are not merged across files (unlike class
+    definitions). Two YAML files declaring the same top-level method name would
+    have silently overwritten one another in `create_analyzers` — surface this as a
+    hard error at load time."""
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+
+    _ = first.write_text(
+        """
+- type: method
+  name: ToString
+  dynamic_name: true
+  signatures:
+    - type: regex
+      signature: 'const-string v\\d+, "(?P<method_name>\\w+)\\{state='
+""".strip()
+    )
+    _ = second.write_text(
+        """
+- type: method
+  name: ToString
+  dynamic_name: true
+  signatures:
+    - type: regex
+      signature: 'const-string v\\d+, "(?P<method_name>\\w+)_TOKEN"'
+""".strip()
+    )
+
+    with pytest.raises(DuplicateTopLevelDefinitionError) as exc_info:
+        _ = _read_definitions([first, second])
+    assert exc_info.value.analyzer_name == "ToString"
+    assert exc_info.value.definition_kind == "method"

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from sigmatcher.cli import _read_definitions  # pyright: ignore[reportPrivateUsage]
-from sigmatcher.definitions import RegexSignature
+from sigmatcher.definitions import ClassDefinition, RegexSignature
 
 
 def test_read_definitions_merges_definition_groups(tmp_path: Path) -> None:
@@ -38,6 +38,7 @@ def test_read_definitions_merges_definition_groups(tmp_path: Path) -> None:
     merged = _read_definitions([base, override])
     assert len(merged) == 1
     class_def = merged[0]
+    assert isinstance(class_def, ClassDefinition)
     signature = class_def.signatures[0]
     assert isinstance(signature, RegexSignature)
     assert signature.signature.pattern == "new-class-signature"

--- a/tests/unit/test_definitions.py
+++ b/tests/unit/test_definitions.py
@@ -114,7 +114,10 @@ def test_dynamic_name_validator_requires_group() -> None:
 
 
 def test_dynamic_name_validator_forbids_group_when_false() -> None:
-    with pytest.raises(pydantic.ValidationError, match="dynamic_name"):
+    with pytest.raises(
+        pydantic.ValidationError,
+        match=r"contains a \(\?P<class_name>\.\.\.\) named group but dynamic_name is not set",
+    ):
         ClassDefinition(
             name="StaticClass",
             signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<class_name>\w+)")),),

--- a/tests/unit/test_definitions.py
+++ b/tests/unit/test_definitions.py
@@ -180,6 +180,35 @@ def test_class_name_group_survives_macro_resolution() -> None:
     assert resolved.capture_class_name('new-instance v0, Lcom/example/Other; foo bar "Captured{state=') == {"Captured"}
 
 
+def test_top_level_method_def_requires_dynamic_name_true() -> None:
+    """Top-level method/field/export defs only make sense in the dynamic_name=True
+    shape — static methods/fields/exports belong inside a class definition."""
+    with pytest.raises(pydantic.ValidationError, match="dynamic_name=False"):
+        TopLevelMethodDefinition(
+            name="StaticMethod",
+            dynamic_name=False,
+            signatures=(RegexSignature(type="regex", signature=re.compile(r"plain pattern")),),
+        )
+
+
+def test_top_level_field_def_requires_dynamic_name_true() -> None:
+    with pytest.raises(pydantic.ValidationError, match="dynamic_name=False"):
+        TopLevelFieldDefinition(
+            name="StaticField",
+            dynamic_name=False,
+            signatures=(RegexSignature(type="regex", signature=re.compile(r"plain pattern")),),
+        )
+
+
+def test_top_level_export_def_requires_dynamic_name_true() -> None:
+    with pytest.raises(pydantic.ValidationError, match="dynamic_name=False"):
+        TopLevelExportDefinition(
+            name="StaticExport",
+            dynamic_name=False,
+            signatures=(RegexSignature(type="regex", signature=re.compile(r"plain pattern")),),
+        )
+
+
 def test_top_level_method_def_round_trip() -> None:
     raw_yaml = [
         {

--- a/tests/unit/test_definitions.py
+++ b/tests/unit/test_definitions.py
@@ -122,6 +122,28 @@ def test_dynamic_name_validator_forbids_group_when_false() -> None:
         )
 
 
+def test_merge_definitions_groups_revalidates_dynamic_name_consistency() -> None:
+    """Merging a non-dynamic base with a dynamic override (whose signature carries the
+    `class_name` group) used to silently produce a ClassDefinition with
+    dynamic_name=False because pydantic's model_copy does not run validators. The merge
+    should re-run the consistency check and reject this inconsistency."""
+    base = ClassDefinition(
+        name="ConnectionManager",
+        signatures=(RegexSignature(type="regex", signature=re.compile(r"plain pattern")),),
+        dynamic_name=False,
+    )
+    override = ClassDefinition(
+        name="ConnectionManager",
+        signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<class_name>\w+)\{state=")),),
+        dynamic_name=True,
+    )
+    with pytest.raises(
+        pydantic.ValidationError,
+        match=r"contains a \(\?P<class_name>\.\.\.\) named group but dynamic_name is not set",
+    ):
+        _ = merge_definitions_groups([[base], [override]])
+
+
 def test_dynamic_name_validator_accepts_consistent_definitions() -> None:
     dynamic = ClassDefinition(
         name="UnknownClass",

--- a/tests/unit/test_definitions.py
+++ b/tests/unit/test_definitions.py
@@ -4,15 +4,21 @@ import pydantic
 import pytest
 
 from sigmatcher.definitions import (
+    DEFINITIONS_TYPE_ADAPTER,
     ClassDefinition,
     CountRange,
     GlobSignature,
     MacroStatement,
     MethodDefinition,
     RegexSignature,
+    TopLevelExportDefinition,
+    TopLevelFieldDefinition,
+    TopLevelMethodDefinition,
     is_in_version_range,
     merge_definitions_groups,
+    validate_definitions,
 )
+from sigmatcher.errors import MacroPointsToDynamicError
 
 EXACT_COUNT = 2
 
@@ -172,3 +178,93 @@ def test_class_name_group_survives_macro_resolution() -> None:
     resolved = signature.resolve_macro(MacroStatement("OtherClass", "java"), "Lcom/example/Other;")
     assert "class_name" in resolved.signature.groupindex
     assert resolved.capture_class_name('new-instance v0, Lcom/example/Other; foo bar "Captured{state=') == {"Captured"}
+
+
+def test_top_level_method_def_round_trip() -> None:
+    raw_yaml = [
+        {
+            "type": "method",
+            "name": "ToString",
+            "dynamic_name": True,
+            "signatures": [
+                {"type": "regex", "signature": r'const-string v\d+, "(?P<method_name>\w+)\{state='},
+            ],
+        }
+    ]
+    definitions = DEFINITIONS_TYPE_ADAPTER.validate_python(raw_yaml)
+    assert len(definitions) == 1
+    method_def = definitions[0]
+    assert isinstance(method_def, TopLevelMethodDefinition)
+    assert method_def.name == "ToString"
+    assert method_def.dynamic_name
+
+
+def test_top_level_field_def_round_trip() -> None:
+    raw_yaml = [
+        {
+            "type": "field",
+            "name": "EventBus",
+            "dynamic_name": True,
+            "signatures": [
+                {
+                    "type": "regex",
+                    "signature": r"^\.field private final (?P<match>.+:Lcom/(?P<field_name>\w+)/Bus;)",
+                },
+            ],
+        }
+    ]
+    definitions = DEFINITIONS_TYPE_ADAPTER.validate_python(raw_yaml)
+    assert isinstance(definitions[0], TopLevelFieldDefinition)
+    assert definitions[0].dynamic_name
+
+
+def test_top_level_export_def_round_trip() -> None:
+    raw_yaml = [
+        {
+            "type": "export",
+            "name": "ApiVersion",
+            "dynamic_name": True,
+            "signatures": [
+                {"type": "regex", "signature": r'"api/v(?P<export_name>\d+)/"'},
+            ],
+        }
+    ]
+    definitions = DEFINITIONS_TYPE_ADAPTER.validate_python(raw_yaml)
+    assert isinstance(definitions[0], TopLevelExportDefinition)
+    assert definitions[0].dynamic_name
+
+
+def test_backward_compat_no_type_field() -> None:
+    """A bare list of class defs without `type:` must keep validating (decision #1)."""
+    raw_yaml = [
+        {
+            "name": "ConnectionManager",
+            "signatures": [
+                {"type": "regex", "signature": "old-class-signature"},
+            ],
+            "methods": [
+                {
+                    "name": "read",
+                    "signatures": [{"type": "regex", "signature": "old-method-signature"}],
+                },
+            ],
+        }
+    ]
+    definitions = DEFINITIONS_TYPE_ADAPTER.validate_python(raw_yaml)
+    assert isinstance(definitions[0], ClassDefinition)
+    assert definitions[0].name == "ConnectionManager"
+
+
+def test_validate_macro_points_at_dynamic() -> None:
+    """Validator must raise at load time, after merge_definitions_groups."""
+    dynamic = ClassDefinition(
+        name="Dyn",
+        dynamic_name=True,
+        signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<class_name>\w+)\{state=")),),
+    )
+    consumer = ClassDefinition(
+        name="Consumer",
+        signatures=(RegexSignature(type="regex", signature=re.compile(r"new-instance v0, ${Dyn.java}")),),
+    )
+    with pytest.raises(MacroPointsToDynamicError):
+        validate_definitions([dynamic, consumer])

--- a/tests/unit/test_definitions.py
+++ b/tests/unit/test_definitions.py
@@ -1,5 +1,8 @@
 import re
 
+import pydantic
+import pytest
+
 from sigmatcher.definitions import (
     ClassDefinition,
     CountRange,
@@ -76,3 +79,71 @@ def test_merge_definitions_groups_prefers_last_signatures_and_merges_children() 
     assert isinstance(signature, RegexSignature)
     assert signature.signature.pattern == "new"
     assert {method.name for method in merged_class.methods} == {"read", "write"}
+
+
+def test_capture_class_name_extracts_single_value() -> None:
+    signature = RegexSignature.model_validate({"type": "regex", "signature": r'"(?P<class_name>\w+)\{state='})
+    assert signature.capture_class_name('const-string v0, "ConnectionManager{state=connected"') == {"ConnectionManager"}
+
+
+def test_capture_class_name_extracts_multiple_distinct() -> None:
+    signature = RegexSignature.model_validate({"type": "regex", "signature": r'"(?P<class_name>\w+)\{state='})
+    captures = signature.capture_class_name('const-string v0, "Alpha{state="\nconst-string v1, "Beta{state="\n')
+    assert captures == {"Alpha", "Beta"}
+
+
+def test_capture_class_name_returns_empty_when_pattern_misses() -> None:
+    signature = RegexSignature.model_validate({"type": "regex", "signature": r'"(?P<class_name>\w+)\{state='})
+    assert signature.capture_class_name("nothing here") == set()
+
+
+def test_has_class_name_group_reflects_pattern() -> None:
+    with_group = RegexSignature.model_validate({"type": "regex", "signature": r"(?P<class_name>\w+)"})
+    without_group = RegexSignature.model_validate({"type": "regex", "signature": r"\w+"})
+    assert with_group.has_class_name_group()
+    assert not without_group.has_class_name_group()
+
+
+def test_dynamic_name_validator_requires_group() -> None:
+    with pytest.raises(pydantic.ValidationError, match="class_name"):
+        ClassDefinition(
+            name="UnknownClass",
+            signatures=(RegexSignature(type="regex", signature=re.compile(r"plain pattern")),),
+            dynamic_name=True,
+        )
+
+
+def test_dynamic_name_validator_forbids_group_when_false() -> None:
+    with pytest.raises(pydantic.ValidationError, match="dynamic_name"):
+        ClassDefinition(
+            name="StaticClass",
+            signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<class_name>\w+)")),),
+            dynamic_name=False,
+        )
+
+
+def test_dynamic_name_validator_accepts_consistent_definitions() -> None:
+    dynamic = ClassDefinition(
+        name="UnknownClass",
+        signatures=(RegexSignature(type="regex", signature=re.compile(r"(?P<class_name>\w+)\{state=")),),
+        dynamic_name=True,
+    )
+    assert dynamic.dynamic_name
+
+    static = ClassDefinition(
+        name="StaticClass",
+        signatures=(RegexSignature(type="regex", signature=re.compile(r"plain pattern")),),
+    )
+    assert not static.dynamic_name
+
+
+def test_class_name_group_survives_macro_resolution() -> None:
+    signature = RegexSignature.model_validate(
+        {
+            "type": "regex",
+            "signature": r"new-instance .+, ${OtherClass.java}.*?(?P<class_name>\w+)\{state=",
+        }
+    )
+    resolved = signature.resolve_macro(MacroStatement("OtherClass", "java"), "Lcom/example/Other;")
+    assert "class_name" in resolved.signature.groupindex
+    assert resolved.capture_class_name('new-instance v0, Lcom/example/Other; foo bar "Captured{state=') == {"Captured"}

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -1,5 +1,18 @@
-from sigmatcher.formats import MappingFormat, convert_to_format, parse_from_format
-from sigmatcher.results import Class, MatchedClass
+import pytest
+
+from sigmatcher.errors import DuplicateCapturedNameError
+from sigmatcher.formats import MappingFormat, convert_to_format, flatten_analyzer_results, parse_from_format
+from sigmatcher.results import (
+    Class,
+    Export,
+    Field,
+    MatchedClass,
+    MatchedExport,
+    MatchedField,
+    MatchedMethod,
+    Method,
+    Result,
+)
 
 
 def test_raw_format_excludes_smali_file(sample_matched_class: MatchedClass) -> None:
@@ -71,3 +84,89 @@ def test_legacy_formatter_sorts_by_captured_original_name(
     zeta = sample_matched_class.model_copy(update={"original": Class(name="Zeta", package="com.example.old")})
     legacy = convert_to_format({"Z_placeholder": zeta, "A_placeholder": alpha}, MappingFormat.LEGACY)
     assert legacy.index('"Alpha"') < legacy.index('"Zeta"')
+
+
+def _make_class(original_name: str, new_name: str) -> MatchedClass:
+    return MatchedClass(
+        original=Class(name=original_name, package="com.example.old"),
+        new=Class(name=new_name, package="com.example"),
+        matched_methods=[],
+        matched_fields=[],
+        exports=[],
+    )
+
+
+def test_raw_format_multi_match() -> None:
+    """Multiple captured names from a dynamic class def each surface as top-level keys."""
+    alpha = _make_class("Alpha", "a")
+    beta = _make_class("Beta", "b")
+    analyzer_results: dict[str, list[Result]] = {"DynamicClass": [alpha, beta]}
+    flattened = flatten_analyzer_results(analyzer_results)
+    raw = convert_to_format(flattened, MappingFormat.RAW)
+    assert '"Alpha"' in raw
+    assert '"Beta"' in raw
+
+
+def test_legacy_format_multi_match() -> None:
+    alpha = _make_class("Alpha", "a")
+    beta = _make_class("Beta", "b")
+    flattened = flatten_analyzer_results({"DynamicClass": [alpha, beta]})
+    legacy = convert_to_format(flattened, MappingFormat.LEGACY)
+    assert '"Alpha"' in legacy
+    assert '"Beta"' in legacy
+
+
+def test_enigma_format_multi_match_round_trip() -> None:
+    alpha = _make_class("Alpha", "a")
+    beta = _make_class("Beta", "b")
+    flattened = flatten_analyzer_results({"DynamicClass": [alpha, beta]})
+    enigma = convert_to_format(flattened, MappingFormat.ENIGMA)
+    parsed = parse_from_format(enigma, MappingFormat.ENIGMA)
+    assert {parsed["Alpha"].new.name, parsed["Beta"].new.name} == {"a", "b"}
+
+
+def test_jadx_format_multi_match_round_trip() -> None:
+    alpha = _make_class("Alpha", "a")
+    beta = _make_class("Beta", "b")
+    flattened = flatten_analyzer_results({"DynamicClass": [alpha, beta]})
+    jadx = convert_to_format(flattened, MappingFormat.JADX)
+    parsed = parse_from_format(jadx, MappingFormat.JADX)
+    assert {parsed["Alpha"].new.name, parsed["Beta"].new.name} == {"a", "b"}
+
+
+def test_format_collision_raises() -> None:
+    """Two analyzers capturing the same readable name must hard-error (decision #9)."""
+    first = _make_class("Shared", "a")
+    second = _make_class("Shared", "b")
+    with pytest.raises(DuplicateCapturedNameError) as exc_info:
+        _ = flatten_analyzer_results({"FirstAnalyzer": [first], "SecondAnalyzer": [second]})
+    assert exc_info.value.captured_name == "Shared"
+
+
+def test_flatten_synthesizes_holder_for_top_level_method() -> None:
+    """Top-level dynamic method results land in a synthesized holder class entry
+    keyed by the obfuscated parent class (decision #10)."""
+    smali_class = Class(name="a", package="com.example")
+    method = MatchedMethod(
+        original=Method(name="toString", argument_types="", return_type="Ljava/lang/String;"),
+        new=Method(name="x", argument_types="", return_type="Ljava/lang/String;"),
+        smali_class=smali_class,
+    )
+    flattened = flatten_analyzer_results({"DynToString": [method]})
+    assert "a" in flattened
+    holder = flattened["a"]
+    assert holder.matched_methods == [method]
+
+
+def test_flatten_synthesizes_holder_for_top_level_field_and_export() -> None:
+    smali_class = Class(name="a", package="com.example")
+    field = MatchedField(
+        original=Field(name="b", type="I"),
+        new=Field(name="b", type="I"),
+        smali_class=smali_class,
+    )
+    export = MatchedExport(new=Export(name="VERSION", value="1.0"), smali_class=smali_class)
+    flattened = flatten_analyzer_results({"DynField": [field], "DynExport": [export]})
+    holder = flattened["a"]
+    assert holder.matched_fields == [field]
+    assert holder.exports == [export]

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -172,6 +172,29 @@ def test_flatten_synthesizes_holder_for_top_level_field_and_export() -> None:
     assert holder.exports == [export]
 
 
+def test_enigma_format_is_order_deterministic() -> None:
+    """Pin that EnigmaFormatter sorts entries by readable original.name regardless of
+    the dict insertion order — output diffability across runs depends on it."""
+    alpha = _make_class("Alpha", "x")
+    beta = _make_class("Beta", "y")
+    zeta = _make_class("Zeta", "z")
+    forward = convert_to_format({"A": alpha, "B": beta, "Z": zeta}, MappingFormat.ENIGMA)
+    reversed_order = convert_to_format({"Z": zeta, "B": beta, "A": alpha}, MappingFormat.ENIGMA)
+    assert forward == reversed_order
+    # Sorted ascending by original.name.
+    assert forward.index("Alpha") < forward.index("Beta") < forward.index("Zeta")
+
+
+def test_jadx_format_is_order_deterministic() -> None:
+    alpha = _make_class("Alpha", "x")
+    beta = _make_class("Beta", "y")
+    zeta = _make_class("Zeta", "z")
+    forward = convert_to_format({"A": alpha, "B": beta, "Z": zeta}, MappingFormat.JADX)
+    reversed_order = convert_to_format({"Z": zeta, "B": beta, "A": alpha}, MappingFormat.JADX)
+    assert forward == reversed_order
+    assert forward.index("Alpha") < forward.index("Beta") < forward.index("Zeta")
+
+
 def test_flatten_does_not_synthesize_holder_for_nested_static_children() -> None:
     """Children of a class analyzer (e.g. `ConnectionManager.methods.read`) carry a
     `smali_class` attribute on their pydantic model — same shape as the top-level

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -170,3 +170,47 @@ def test_flatten_synthesizes_holder_for_top_level_field_and_export() -> None:
     holder = flattened["a"]
     assert holder.matched_fields == [field]
     assert holder.exports == [export]
+
+
+def test_flatten_does_not_synthesize_holder_for_nested_static_children() -> None:
+    """Children of a class analyzer (e.g. `ConnectionManager.methods.read`) carry a
+    `smali_class` attribute on their pydantic model — same shape as the top-level
+    dynamic analyzers' results — but they're already attached to their parent
+    `MatchedClass`. They must NOT be routed into a synthesized holder, otherwise
+    the children would appear twice in the output: once under their parent's
+    captured/static name, once under the obfuscated smali class key.
+
+    Regression test for BLOCKER 1 of the dynamic-redesign CR.
+    """
+    smali_class = Class(name="a", package="com.example")
+    method = MatchedMethod(
+        original=Method(name="read", argument_types="", return_type="V"),
+        new=Method(name="c", argument_types="", return_type="V"),
+        smali_class=smali_class,
+    )
+    field = MatchedField(
+        original=Field(name="counter", type="I"),
+        new=Field(name="b", type="I"),
+        smali_class=smali_class,
+    )
+    parent_class = MatchedClass(
+        original=Class(name="ConnectionManager", package="com.example.old"),
+        new=smali_class,
+        matched_methods=[method],
+        matched_fields=[field],
+        exports=[],
+    )
+    analyzer_results: dict[str, list[Result]] = {
+        "ConnectionManager": [parent_class],
+        "ConnectionManager.methods.read": [method],
+        "ConnectionManager.fields.counter": [field],
+    }
+
+    flattened = flatten_analyzer_results(analyzer_results)
+    # Exactly one entry, keyed by the captured/static readable parent name.
+    assert set(flattened.keys()) == {"ConnectionManager"}
+
+    raw = convert_to_format(flattened, MappingFormat.RAW)
+    # The obfuscated smali class name must not appear as a top-level key in raw output.
+    parsed = parse_from_format(raw, MappingFormat.RAW)
+    assert "a" not in parsed

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -55,3 +55,19 @@ def test_legacy_formatter_includes_exports(sample_matched_class: MatchedClass) -
     legacy = convert_to_format(payload, MappingFormat.LEGACY)
     assert '"exports"' in legacy
     assert '"exportA": "VALUE_A"' in legacy
+
+
+def test_legacy_formatter_uses_captured_original_name_as_key(sample_matched_class: MatchedClass) -> None:
+    payload = {"PlaceholderId": sample_matched_class}
+    legacy = convert_to_format(payload, MappingFormat.LEGACY)
+    assert '"OriginalSample"' in legacy
+    assert '"PlaceholderId"' not in legacy
+
+
+def test_legacy_formatter_sorts_by_captured_original_name(
+    sample_matched_class: MatchedClass,
+) -> None:
+    alpha = sample_matched_class.model_copy(update={"original": Class(name="Alpha", package="com.example.old")})
+    zeta = sample_matched_class.model_copy(update={"original": Class(name="Zeta", package="com.example.old")})
+    legacy = convert_to_format({"Z_placeholder": zeta, "A_placeholder": alpha}, MappingFormat.LEGACY)
+    assert legacy.index('"Alpha"') < legacy.index('"Zeta"')

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -107,6 +107,19 @@ def test_raw_format_multi_match() -> None:
     assert '"Beta"' in raw
 
 
+def test_raw_format_keys_are_sorted() -> None:
+    """RawFormatter relies on json.dumps(sort_keys=True) — pin that contract so a
+    refactor that drops the flag (or that swaps to a non-sorted dump path) is caught."""
+    alpha = _make_class("Alpha", "x")
+    beta = _make_class("Beta", "y")
+    zeta = _make_class("Zeta", "z")
+    forward = convert_to_format({"A": alpha, "B": beta, "Z": zeta}, MappingFormat.RAW)
+    reversed_order = convert_to_format({"Z": zeta, "B": beta, "A": alpha}, MappingFormat.RAW)
+    assert forward == reversed_order
+    # The top-level keys are emitted in sorted order.
+    assert forward.index('"Alpha"') < forward.index('"Beta"') < forward.index('"Zeta"')
+
+
 def test_legacy_format_multi_match() -> None:
     alpha = _make_class("Alpha", "a")
     beta = _make_class("Beta", "b")

--- a/tests/unit/test_formats.py
+++ b/tests/unit/test_formats.py
@@ -208,6 +208,35 @@ def test_jadx_format_is_order_deterministic() -> None:
     assert forward.index("Alpha") < forward.index("Beta") < forward.index("Zeta")
 
 
+def test_flatten_top_level_dynamic_with_dotted_name_is_not_skipped() -> None:
+    """F2 regression: a user-authored top-level dynamic method/field/export definition
+    whose YAML `name` happens to contain `.methods.`/`.fields.`/`.exports.` (e.g. a
+    placeholder identifier like `MyClass.methods.foo`) must NOT be classified as a
+    nested child and silently dropped from output formatting.
+
+    Pre-fix, `flatten_analyzer_results` used a substring heuristic on the analyzer
+    name, so this entry would have been skipped. With the structural marker fix the
+    CLI passes an explicit `child_analyzer_names` set; a top-level dynamic def is not
+    in that set, so its results land in a synthesized holder regardless of the name.
+    """
+    smali_class = Class(name="a", package="com.example")
+    method = MatchedMethod(
+        original=Method(name="surprise", argument_types="", return_type="V"),
+        new=Method(name="x", argument_types="", return_type="V"),
+        smali_class=smali_class,
+    )
+    analyzer_results: dict[str, list[Result]] = {"MyClass.methods.foo": [method]}
+    # The CLI builds this set from the structural marker — no top-level dynamic def
+    # belongs in it, only nested child analyzers. Crucially, "MyClass.methods.foo" is
+    # absent here even though its dotted name shape would have fooled the heuristic.
+    child_analyzer_names: set[str] = set()
+    flattened = flatten_analyzer_results(analyzer_results, child_analyzer_names)
+    # The top-level dynamic method must surface via the synthesized holder keyed by
+    # the obfuscated smali class — not be silently dropped.
+    assert "a" in flattened
+    assert flattened["a"].matched_methods == [method]
+
+
 def test_flatten_does_not_synthesize_holder_for_nested_static_children() -> None:
     """Children of a class analyzer (e.g. `ConnectionManager.methods.read`) carry a
     `smali_class` attribute on their pydantic model — same shape as the top-level

--- a/uv.lock
+++ b/uv.lock
@@ -717,7 +717,7 @@ wheels = [
 
 [[package]]
 name = "sigmatcher"
-version = "1.9.2"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
Sigmatcher is amazing for manual definitions of classes and methods. This is great for researchers who are interested in a select few classes for which they can research in depth to find a matching name, based on the classes behavior.

Not all classes are like this though- there's many times where a log can easily reveal the name of the original class, before it was minified. While a researcher can manually go over these cases and add rules to detect and rename them, this is incredibly tedious. Especially more so when there is a very clear name-revealing convention in the logs, disassembly, or other areas of code.

Dynamic signatures allow us to now use patterns to identify classes we haven't even researched manually before!

*Note: The code of this PR was made entirely with AI and needs to be thoroughly reviewed.*

I myself am also CRing the agent.
